### PR TITLE
Enabling pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 script:
 - "./.travis/install.sh"
 - export LDFLAGS="-L$TRAVIS_BUILD_DIR/lib -L/usr/local/lib -Wl,-rpath=$TRAVIS_BUILD_DIR/lib -Wl,-rpath=/usr/local/lib"
-- python setup.py install
+- export CFLAGS="-I$TRAVIS_BUILD_DIR/include -I/usr/local/include -fopenmp"
+- pip install .
 - export LD_LIBRARY_PATH=$TRAVIS_BUILD/lib:/usr/local/lib:$LD_LIBRARY_PATH
 - python -m unittest discover -v
-

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-#### Install NaMaster C ####
-
 export PATH=$TRAVIS_BUILD_DIR/bin:$PATH
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TRAVIS_BUILD_DIR/lib:/usr/local/lib
 export LDFLAGS="-L$TRAVIS_BUILD_DIR/lib -L/usr/local/lib"
 export CPPFLAGS="-I$TRAVIS_BUILD_DIR/include -I/usr/local/include -fopenmp"
 export CFLAGS="-fopenmp"
 
-./configure --prefix=$TRAVIS_BUILD_DIR
-make clean
-make
-sudo make install
-make check
+#### Install NaMaster C ####
+
+#./configure --prefix=$TRAVIS_BUILD_DIR
+#make clean
+#make
+#sudo make install
+#make check

--- a/.travis/install_deps.sh
+++ b/.travis/install_deps.sh
@@ -6,7 +6,7 @@ wget https://sourceforge.net/projects/healpix/files/Healpix_3.11/autotools_packa
 
 # Install healpy and nose
 
-pip install nose healpy scipy
+pip install nose healpy scipy setuptools
 
 #### Install libsharp ####
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,20 @@
+include Makefile.am
+include Makefile.in
+include README.md
+include aclocal.m4
+include ar-lib
+include compile
+include config.guess
+include config.h.in
+include config.sub
+include configure
+include configure.ac
+include depcomp
+include install-sh
+include ltmain.sh
+include missing
+include setup.py
+recursive-include src/ ./*
+recursive-include pymaster/ ./*
+recursive-include test/ ./*
+recursive-include test/benchmark/ ./*

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,216 @@
 #!/usr/bin/env python
-
-from distutils.core import *
-from distutils import sysconfig
-import os.path
-
-# Get numpy include directory (works across versions)
+from __future__ import print_function
+import os
+import sys
+from distutils import log, ccompiler
+from distutils.cmd import Command
+from setuptools import setup
+from distutils.errors import CompileError, LinkError
+from distutils.extension import Extension
+from distutils.sysconfig import customize_compiler, get_config_var, get_config_vars
+from distutils.util import get_platform
+from setuptools.command.install import install as DistutilsInstall
+from setuptools.command.build_clib import build_clib as BuildCLib
+from distutils.dir_util import mkpath
+import platform
+import shutil
+import site
+from subprocess import check_call, call
+import tempfile
+from textwrap import dedent
+# Implicit requirement - numpy must already be installed
 import numpy
 try:
     numpy_include = numpy.get_include()
 except AttributeError:
     numpy_include = numpy.get_numpy_include()
 
+class BuildExternalCLib(BuildCLib):
+    """Customized build"""
+
+    def __init__(self, dist):
+        BuildCLib.__init__(self, dist)
+        self.build_args = {}
+
+    def build_library(self,library):
+        # Use a subdirectory of build_temp as the build directory.
+        target_temp = os.path.realpath(os.path.join(self.build_temp, library))
+        # Destination for headers and libraries is build_clib.
+        target_clib = os.path.realpath(self.build_clib)
+
+        # Create build directories if they do not yet exist.
+        mkpath(target_temp)
+        mkpath(target_clib)
+
+        env = _get_build_env()
+
+        # Run configure.
+        cmd = ['/bin/sh', os.path.join(os.path.dirname(__file__), 'configure'),
+            '--prefix=' + target_clib,
+            '--enable-shared',
+            '--with-pic',]
+
+        log.info('%s', ' '.join(cmd))
+        check_call(cmd, cwd='./', env=env)
+
+        # Run make install.
+        cmd = ['make', 'install']
+        log.info('%s', ' '.join(cmd))
+        check_call(cmd, cwd='./', env=env)
+        return target_clib
+
+    def run(self):
+        build_path = self.build_library('nmt')
+        BuildCLib.run(self)
+
+# Creating the PyTest command
+class PyTest(Command):
+    # This assumes that the package is located in the default prefix.
+    # If not, you have to add the path where you installed the C library
+    # to DYLD_LIBARY_PATH or LD_LIBRARY_PATH depending on your platform.
+
+    lib_env = 'LD_LIBARY_PATH' 
+    if lib_env not in os.environ:
+        libpath = os.getenv(lib_env, os.path.join(sys.prefix, 'lib'))
+        os.environ[lib_env] = libpath
+        libpath2 = os.path.realpath(os.path.join(site.USER_BASE, 'lib'))
+        os.environ[lib_env] += os.path.join(libpath2)
+    else:
+        os.environ[lib_env] += os.pathsep + os.path.join(sys.prefix, 'lib')
+        libpath2 = os.path.realpath(os.path.join(site.USER_BASE, 'lib'))
+        os.environ[lib_env] += os.path.join(libpath2)
+
+    user_options = []
+
+    def initialize_options(self):
+
+        pass
+
+    def finalize_options(self):
+
+        pass
+
+    def run(self):
+
+        errno = call([sys.executable, '-m unittest discover -v'])
+        raise SystemExit(errno)
+
+
+class PyUninstall(DistutilsInstall):
+    def __init__(self, dist):
+        DistutilsInstall.__init__(self, dist)
+        self.build_args = {}
+        if self.record is None:
+            self.record = 'install-record.txt'
+
+    def run(self):
+        print("Removing...")
+        os.system("cat %s | xargs rm -rfv" % self.record)
+
+class PyInstall(DistutilsInstall):
+    def __init__(self, dist):
+        DistutilsInstall.__init__(self, dist)
+        self.build_args = {}
+        if self.record is None:
+            self.record = 'install-record.txt'
+
+    def build_library(self, library):
+        plat_specifier = ".%s-%s" % (get_platform(), sys.version[0:3])
+        if self.user:
+            self.build_temp = os.path.join(self.install_userbase, 'temp' + plat_specifier)
+        else:
+            self.build_temp = os.path.join(self.prefix, 'temp' + plat_specifier)
+
+        # Use a subdirectory of build_temp as the build directory.
+        target_temp = os.path.realpath(os.path.join(self.build_temp, library))
+        # Destination for headers and libraries is build_clib.
+        if self.user:
+            target_clib = os.path.realpath(self.install_userbase)
+        else:
+            target_clib = os.path.realpath(self.prefix)
+
+        # Create build directories if they do not yet exist.
+        mkpath(target_temp)
+        mkpath(target_clib)
+
+        env = _get_build_env()
+        # Run configure.
+        cmd = ['/bin/sh', os.path.join(os.path.dirname(__file__), 'configure'),
+            '--prefix=' + target_clib]
+        log.info('%s', ' '.join(cmd))
+        check_call(cmd, cwd='./', env=env)
+        # Run make install.
+        cmd = ['make', 'install']
+        log.info('%s', ' '.join(cmd))
+        check_call(cmd, cwd='./', env=env)
+        return target_clib
+
+    def run(self):
+        # Uncomment the line below if you want to check if the C library
+        # is installed and in your path.
+        # ret_val = self.check_extensions()
+        lib_path = self.build_library('_nmtlib')
+        DistutilsInstall.run(self)
+
+def _get_build_env():
+    env = dict(os.environ)
+    cc, cxx, opt, cflags = get_config_vars('CC', 'CXX', 'OPT', 'CFLAGS')
+    if 'CFLAGS' in env:
+        env['CFLAGS'] = opt + ' ' + env['CFLAGS'] 
+    return env
+
+def _check_nmt():
+    """check if the C module can be built by trying to compile a small
+    program against nmt"""
+
+    libraries = ['nmt']
+
+    # write a temporary .c file to compile
+    c_code = dedent("""
+    #include <stdio.h>
+    #define CTEST_MAIN
+    #include "ctest.h"
+    int main(int argc, const char *argv[])
+    {
+      int result = ctest_main(argc, argv);
+      return result;
+    }
+    """)
+    tmp_dir = tempfile.mkdtemp(prefix='tmp_ccl_')
+    bin_file_name = os.path.join(tmp_dir, 'test_ccl')
+    file_name = bin_file_name + '.c'
+    with open(file_name, 'w') as fp:
+        fp.write(c_code)
+    # and try to compile it
+    compiler = ccompiler.new_compiler()
+    assert isinstance(compiler, ccompiler.CCompiler)
+    customize_compiler(compiler)
+
+    try:
+        compiler.link_executable(
+            compiler.compile([file_name]),
+            bin_file_name,
+            libraries=libraries,
+        )
+        ret_val = True
+    except CompileError:
+        print('libccl compile error')
+        ret_val = False
+    except LinkError:
+        print('libccl link error')
+        ret_val = False
+    shutil.rmtree(tmp_dir)
+    return ret_val
+
+# CCL setup script
+
+if "--user" in sys.argv:
+    libdir=os.path.realpath(os.path.join(site.USER_BASE,'lib'))
+elif "--prefix" in sys.argv:
+    ii = np.where(np.array(sys.argv)=="--prefix")
+    libdir=os.path.realpath(os.path.join(sys.argv[ii+1],'lib'))
+else:
+    libdir=os.path.realpath(os.path.join(sys.prefix,'lib'))
 
 use_icc=False #Set to True if you compiled libsharp with icc
 if use_icc :
@@ -20,18 +220,43 @@ else :
     libs=['nmt','fftw3','fftw3_omp','sharp','fftpack','c_utils','chealpix','cfitsio','gsl','gslcblas','m','gomp']
     extra=['-O4', '-fopenmp',]
 
-
-_nmtlib = Extension("_nmtlib",
+# We check if we can compile a script against the C nmt library
+if _check_nmt():
+    # If the C library is installed, then we just install the Python library 
+    _nmtlib = Extension("_nmtlib",
                     ["pymaster/namaster_wrap.c"],
                     libraries = libs,
                     include_dirs = [numpy_include, "../src/"],
                     extra_compile_args=extra,
                     )
+    setup(name = "pymaster",
+          description = "Library for pseudo-Cl computation",
+          author = "David Alonso",
+          version = "0.1",
+          packages = ['pymaster'],
+          ext_modules = [_nmtlib],
+          )
 
-setup(name = "pymaster",
-      description = "Library for pseudo-Cl computation",
-      author = "David Alonso",
-      version = "0.1",
-      packages = ['pymaster'],
-      ext_modules = [_nmtlib],
-      )
+# If this fails, try to install the C library and the Python library
+else:  
+    setup(name="pymaster",
+        description="Library for pseudo-Cl computation",
+        author="David Alonso",
+        version="0.1",
+        packages=['pymaster'],
+        ext_modules=[
+            Extension("_nmtlib",["pymaster/namaster_wrap.c"],
+                libraries=libs,
+                library_dirs=[libdir],
+                runtime_library_dirs=[libdir],
+                include_dirs=[numpy_include, "../src/"],
+                extra_compile_args=extra,
+                )
+        ],
+        cmdclass={
+            'install': PyInstall,
+            'build_clib': BuildExternalCLib,
+            'test': PyTest,
+            'uninstall': PyUninstall
+        }
+        )

--- a/src/nmt_field.c
+++ b/src/nmt_field.c
@@ -151,6 +151,7 @@ void nmt_purify(nmt_field *fl,flouble *mask,fcomplex **walm0,
   free(palm);
   free(walm);
   free(alm_out);
+  free(f_l);
 }
 
 nmt_field *nmt_field_alloc_sph(long nside,flouble *mask,int pol,flouble **maps,


### PR DESCRIPTION
This branch tries to enable pip installing of NaMaster. As it is right now, it checks whether it can compile against `-lnmt` and if it does, it just installs the python block, if not, it installs the C library.

In order to try it, you can either try the usual way `python setup.py install` or, in the root directory, try `pip install .`. In principle, all options should work. Before merging and registering in `pypi` I have to create the `MANIFEST` file but I wanted to check if the current setup works for you @damonge @slosar 