### PR TITLE
added an OMP pragma when extracting covariances

### DIFF
--- a/src/nmt_covar.c
+++ b/src/nmt_covar.c
@@ -171,6 +171,8 @@ void  nmt_compute_gaussian_covariance(nmt_covar_workspace *cw,
 	      int ila;
 	      int icl_b=id+nmaps_d*ic;
 	      double cbinned=0;
+
+#pragma omp parallel for reduction(+:cbinned)
 	      for(ila=0;ila<wa->bin->nell_list[band_a];ila++) {
 		int ilb;
 		int la=wa->bin->ell_list[band_a][ila];

--- a/src/nmt_covar.c
+++ b/src/nmt_covar.c
@@ -155,8 +155,10 @@ void  nmt_compute_gaussian_covariance(nmt_covar_workspace *cw,
     report_error(NMT_ERROR_COVAR,"Input spins don't match input workspaces\n");
 
   gsl_matrix *covar_binned=gsl_matrix_alloc(wa->ncls*wa->bin->n_bands,wb->ncls*wb->bin->n_bands);
-  int band_a;
-  for(band_a=0;band_a<wa->bin->n_bands;band_a++) {
+
+  //int band_a;
+  #pragma omp parallel for
+  for(int band_a=0;band_a<wa->bin->n_bands;band_a++) {
     int band_b;
     for(band_b=0;band_b<wb->bin->n_bands;band_b++) {
       int ia;
@@ -172,7 +174,7 @@ void  nmt_compute_gaussian_covariance(nmt_covar_workspace *cw,
 	      int icl_b=id+nmaps_d*ic;
 	      double cbinned=0;
 
-#pragma omp parallel for reduction(+:cbinned)
+
 	      for(ila=0;ila<wa->bin->nell_list[band_a];ila++) {
 		int ilb;
 		int la=wa->bin->ell_list[band_a][ila];


### PR DESCRIPTION
With an [unscientific benchmark](https://gist.github.com/xzackli/872f5f539850291ccbee6c5b0ae49319) on nside 1024, I get for **serial** (timings in seconds is the last number)
```
extract 0000 0.4997720718383789
extract 0202 2.6853466033935547
extract 0022 2.6666736602783203
extract 0222 9.335917234420776
extract 2222 35.033103942871094
```
Using this OMP pragma,
```
extract 0000 0.7780139446258545
extract 0202 1.586399793624878
extract 0022 1.6467950344085693
extract 0222 3.7184906005859375
extract 2222 9.556730270385742
```
This uses 40 cores on a tiger node (so the scaling is _really_ bad.


