### PR TITLE
make lmax tunable

### DIFF
--- a/pymaster/field.py
+++ b/pymaster/field.py
@@ -54,7 +54,7 @@ class NmtField(object):
     """
     def __init__(self, mask, maps, templates=None, beam=None,
                  purify_e=False, purify_b=False, n_iter_mask_purify=3,
-                 tol_pinv=1E-10, wcs=None, n_iter=3):
+                 tol_pinv=1E-10, wcs=None, n_iter=3, lmax_sht=-1):
         self.fl = None
 
         pure_e = 0
@@ -112,7 +112,10 @@ class NmtField(object):
                 raise ValueError("Input templates can only be an array "
                                  "or None\n")
 
-        lmax = wt.get_lmax()
+        if lmax_sht is not -1:
+            lmax = lmax_sht
+        else:
+            lmax = wt.get_lmax()
 
         if isinstance(beam, (list, tuple, np.ndarray)):
             if len(beam) <= lmax:
@@ -126,7 +129,7 @@ class NmtField(object):
                 raise ValueError("Input beam can only be an array or None\n")
 
         if isinstance(templates, (list, tuple, np.ndarray)):
-            self.fl = lib.field_alloc_new(wt.is_healpix, wt.nside,
+            self.fl = lib.field_alloc_new(wt.is_healpix, wt.nside, lmax_sht,
                                           wt.nx, wt.ny,
                                           wt.d_phi, wt.d_theta,
                                           wt.phi0, wt.theta_max,
@@ -135,7 +138,7 @@ class NmtField(object):
                                           tol_pinv, n_iter)
         else:
             self.fl = lib.field_alloc_new_notemp(
-                wt.is_healpix, wt.nside, wt.nx, wt.ny, wt.d_phi,
+                wt.is_healpix, wt.nside, lmax_sht, wt.nx, wt.ny, wt.d_phi,
                 wt.d_theta, wt.phi0, wt.theta_max,
                 mask, maps, beam_use, pure_e, pure_b, n_iter_mask_purify,
                 n_iter)

--- a/pymaster/field.py
+++ b/pymaster/field.py
@@ -51,6 +51,9 @@ class NmtField(object):
     :param wcs: a WCS object if using rectangular pixels (see \
         http://docs.astropy.org/en/stable/wcs/index.html).
     :param n_iter: number of iterations when computing a_lms.
+    :param lmax_sht: maximum multipole up to which map power spectra will be
+        computed. If negative or zero, the maximum multipole given the map
+        resolution will be used (e.g. 3 * nside - 1 for HEALPix maps).
     """
     def __init__(self, mask, maps, templates=None, beam=None,
                  purify_e=False, purify_b=False, n_iter_mask_purify=3,
@@ -112,7 +115,7 @@ class NmtField(object):
                 raise ValueError("Input templates can only be an array "
                                  "or None\n")
 
-        if lmax_sht is not -1:
+        if lmax_sht > 0:
             lmax = lmax_sht
         else:
             lmax = wt.get_lmax()

--- a/pymaster/namaster.i
+++ b/pymaster/namaster.i
@@ -88,7 +88,7 @@ void get_weight_list(nmt_binning_scheme *bins,int ibin,double *dout,int ndout)
 int get_lmax_py(int is_healpix,int nside,int nx,int ny,
 		double delta_phi,double delta_theta,double phi0,double theta0)
 {
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,(long)nside,nx,ny,
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,(long)nside,-1,nx,ny,
 						  delta_theta,delta_phi,phi0,theta0);
   int lmax=he_get_lmax(cs);
   free(cs);
@@ -238,7 +238,7 @@ void unbin_cl_flat(nmt_binning_scheme_flat *bins,
   free(cls_out);
 }
 
-nmt_field *field_alloc_new(int is_healpix,int nside,int nx,int ny,double delta_phi,
+nmt_field *field_alloc_new(int is_healpix,int nside,int lmax_sht,int nx,int ny,double delta_phi,
 			   double delta_theta,double phi0,double theta0,
 			   int npix_1,double *mask,
 			   int nmap_2,int npix_2,double *mps,
@@ -263,7 +263,7 @@ nmt_field *field_alloc_new(int is_healpix,int nside,int nx,int ny,double delta_p
   else
     asserting(npix_1==nx*ny);
 
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,nside_l,nx,ny,
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,nside_l,lmax_sht,nx,ny,
 						  delta_theta,delta_phi,phi0,theta0);
   asserting(nell3>he_get_lmax(cs));
 
@@ -297,7 +297,7 @@ nmt_field *field_alloc_new(int is_healpix,int nside,int nx,int ny,double delta_p
   return fl;
 }
 
-nmt_field *field_alloc_new_notemp(int is_healpix,int nside,int nx,int ny,double delta_phi,
+nmt_field *field_alloc_new_notemp(int is_healpix,int nside,int lmax_sht,int nx,int ny,double delta_phi,
 				  double delta_theta,double phi0,double theta0,
 				  int npix_1,double *mask,
 				  int nmap_2,int npix_2,double *mps,
@@ -317,7 +317,7 @@ nmt_field *field_alloc_new_notemp(int is_healpix,int nside,int nx,int ny,double 
   else
     asserting(npix_1==nx*ny);
 
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,nside_l,nx,ny,
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,nside_l,lmax_sht,nx,ny,
 						  delta_theta,delta_phi,phi0,theta0);
   asserting(nell3>he_get_lmax(cs));
 
@@ -488,7 +488,7 @@ void synfast_new(int is_healpix,int nside,int nx,int ny,double delta_phi,
       nmaps+=2;
   }
 
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,nside_l,nx,ny,
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,nside_l,-1,nx,ny,
 						  delta_theta,delta_phi,phi0,theta0);
   asserting(ncl2==nfields);
   asserting(ncl1==(nmaps*(nmaps+1))/2);

--- a/pymaster/namaster.i
+++ b/pymaster/namaster.i
@@ -566,9 +566,9 @@ void synfast_new_flat(int nx,int ny,double lx,double ly,
 }
 
  nmt_workspace *comp_coupling_matrix(nmt_field *fl1,nmt_field *fl2,nmt_binning_scheme *bin,
-				     int is_teb,int n_iter)
+				     int is_teb,int n_iter,int lmax_mask)
 {
-  return nmt_compute_coupling_matrix(fl1,fl2,bin,is_teb,n_iter);
+  return nmt_compute_coupling_matrix(fl1,fl2,bin,is_teb,n_iter,lmax_mask);
 }
 
 nmt_workspace_flat *comp_coupling_matrix_flat(nmt_field_flat *fl1,nmt_field_flat *fl2,
@@ -911,7 +911,8 @@ void comp_pspec(nmt_field *fl1,nmt_field *fl2,
 		nmt_binning_scheme *bin,nmt_workspace *w0,
 		int ncl1,int nell1,double *cls1,
 		int ncl2,int nell2,double *cls2,
-		double *dout,int ndout,int n_iter)
+		double *dout,int ndout,int n_iter,
+		int lmax_mask)
 {
   int i;
   double **cl_noise,**cl_guess,**cl_out;
@@ -931,7 +932,7 @@ void comp_pspec(nmt_field *fl1,nmt_field *fl2,
     cl_out[i]=&(dout[i*bin->n_bands]);
   }
 
-  w=nmt_compute_power_spectra(fl1,fl2,bin,w0,cl_noise,cl_guess,cl_out,n_iter);
+  w=nmt_compute_power_spectra(fl1,fl2,bin,w0,cl_noise,cl_guess,cl_out,n_iter,lmax_mask);
 
   free(cl_out);
   free(cl_guess);

--- a/pymaster/namaster_wrap.c
+++ b/pymaster/namaster_wrap.c
@@ -3852,9 +3852,9 @@ void synfast_new_flat(int nx,int ny,double lx,double ly,
 }
 
  nmt_workspace *comp_coupling_matrix(nmt_field *fl1,nmt_field *fl2,nmt_binning_scheme *bin,
-				     int is_teb,int n_iter)
+				     int is_teb,int n_iter,int lmax_mask)
 {
-  return nmt_compute_coupling_matrix(fl1,fl2,bin,is_teb,n_iter);
+  return nmt_compute_coupling_matrix(fl1,fl2,bin,is_teb,n_iter,lmax_mask);
 }
 
 nmt_workspace_flat *comp_coupling_matrix_flat(nmt_field_flat *fl1,nmt_field_flat *fl2,
@@ -4197,7 +4197,8 @@ void comp_pspec(nmt_field *fl1,nmt_field *fl2,
 		nmt_binning_scheme *bin,nmt_workspace *w0,
 		int ncl1,int nell1,double *cls1,
 		int ncl2,int nell2,double *cls2,
-		double *dout,int ndout,int n_iter)
+		double *dout,int ndout,int n_iter,
+		int lmax_mask)
 {
   int i;
   double **cl_noise,**cl_guess,**cl_out;
@@ -4217,7 +4218,7 @@ void comp_pspec(nmt_field *fl1,nmt_field *fl2,
     cl_out[i]=&(dout[i*bin->n_bands]);
   }
 
-  w=nmt_compute_power_spectra(fl1,fl2,bin,w0,cl_noise,cl_guess,cl_out,n_iter);
+  w=nmt_compute_power_spectra(fl1,fl2,bin,w0,cl_noise,cl_guess,cl_out,n_iter,lmax_mask);
 
   free(cl_out);
   free(cl_guess);
@@ -12581,6 +12582,7 @@ SWIGINTERN PyObject *_wrap_compute_coupling_matrix(PyObject *SWIGUNUSEDPARM(self
   nmt_binning_scheme *arg3 = (nmt_binning_scheme *) 0 ;
   int arg4 ;
   int arg5 ;
+  int arg6 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 = 0 ;
@@ -12591,14 +12593,17 @@ SWIGINTERN PyObject *_wrap_compute_coupling_matrix(PyObject *SWIGUNUSEDPARM(self
   int ecode4 = 0 ;
   int val5 ;
   int ecode5 = 0 ;
+  int val6 ;
+  int ecode6 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
   PyObject * obj3 = 0 ;
   PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
   nmt_workspace *result = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOOOO:compute_coupling_matrix",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:compute_coupling_matrix",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_nmt_field, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "compute_coupling_matrix" "', argument " "1"" of type '" "nmt_field *""'"); 
@@ -12624,7 +12629,12 @@ SWIGINTERN PyObject *_wrap_compute_coupling_matrix(PyObject *SWIGUNUSEDPARM(self
     SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "compute_coupling_matrix" "', argument " "5"" of type '" "int""'");
   } 
   arg5 = (int)(val5);
-  result = (nmt_workspace *)nmt_compute_coupling_matrix(arg1,arg2,arg3,arg4,arg5);
+  ecode6 = SWIG_AsVal_int(obj5, &val6);
+  if (!SWIG_IsOK(ecode6)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "compute_coupling_matrix" "', argument " "6"" of type '" "int""'");
+  } 
+  arg6 = (int)(val6);
+  result = (nmt_workspace *)nmt_compute_coupling_matrix(arg1,arg2,arg3,arg4,arg5,arg6);
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_nmt_workspace, 0 |  0 );
   return resultobj;
 fail:
@@ -13030,6 +13040,7 @@ SWIGINTERN PyObject *_wrap_compute_power_spectra(PyObject *SWIGUNUSEDPARM(self),
   flouble **arg6 = (flouble **) 0 ;
   flouble **arg7 = (flouble **) 0 ;
   int arg8 ;
+  int arg9 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 = 0 ;
@@ -13046,6 +13057,8 @@ SWIGINTERN PyObject *_wrap_compute_power_spectra(PyObject *SWIGUNUSEDPARM(self),
   int res7 = 0 ;
   int val8 ;
   int ecode8 = 0 ;
+  int val9 ;
+  int ecode9 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -13054,9 +13067,10 @@ SWIGINTERN PyObject *_wrap_compute_power_spectra(PyObject *SWIGUNUSEDPARM(self),
   PyObject * obj5 = 0 ;
   PyObject * obj6 = 0 ;
   PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
   nmt_workspace *result = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOO:compute_power_spectra",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOO:compute_power_spectra",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_nmt_field, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "compute_power_spectra" "', argument " "1"" of type '" "nmt_field *""'"); 
@@ -13097,7 +13111,12 @@ SWIGINTERN PyObject *_wrap_compute_power_spectra(PyObject *SWIGUNUSEDPARM(self),
     SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "compute_power_spectra" "', argument " "8"" of type '" "int""'");
   } 
   arg8 = (int)(val8);
-  result = (nmt_workspace *)nmt_compute_power_spectra(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8);
+  ecode9 = SWIG_AsVal_int(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "compute_power_spectra" "', argument " "9"" of type '" "int""'");
+  } 
+  arg9 = (int)(val9);
+  result = (nmt_workspace *)nmt_compute_power_spectra(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9);
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_nmt_workspace, 0 |  0 );
   return resultobj;
 fail:
@@ -17651,6 +17670,7 @@ SWIGINTERN PyObject *_wrap_comp_coupling_matrix(PyObject *SWIGUNUSEDPARM(self), 
   nmt_binning_scheme *arg3 = (nmt_binning_scheme *) 0 ;
   int arg4 ;
   int arg5 ;
+  int arg6 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 = 0 ;
@@ -17661,14 +17681,17 @@ SWIGINTERN PyObject *_wrap_comp_coupling_matrix(PyObject *SWIGUNUSEDPARM(self), 
   int ecode4 = 0 ;
   int val5 ;
   int ecode5 = 0 ;
+  int val6 ;
+  int ecode6 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
   PyObject * obj3 = 0 ;
   PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
   nmt_workspace *result = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOOOO:comp_coupling_matrix",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:comp_coupling_matrix",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_nmt_field, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "comp_coupling_matrix" "', argument " "1"" of type '" "nmt_field *""'"); 
@@ -17694,9 +17717,14 @@ SWIGINTERN PyObject *_wrap_comp_coupling_matrix(PyObject *SWIGUNUSEDPARM(self), 
     SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "comp_coupling_matrix" "', argument " "5"" of type '" "int""'");
   } 
   arg5 = (int)(val5);
+  ecode6 = SWIG_AsVal_int(obj5, &val6);
+  if (!SWIG_IsOK(ecode6)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "comp_coupling_matrix" "', argument " "6"" of type '" "int""'");
+  } 
+  arg6 = (int)(val6);
   {
     try {
-      result = (nmt_workspace *)comp_coupling_matrix(arg1,arg2,arg3,arg4,arg5);
+      result = (nmt_workspace *)comp_coupling_matrix(arg1,arg2,arg3,arg4,arg5,arg6);
     }
     finally {
       SWIG_exception(SWIG_RuntimeError,nmt_error_message);
@@ -19739,6 +19767,7 @@ SWIGINTERN PyObject *_wrap_comp_pspec(PyObject *SWIGUNUSEDPARM(self), PyObject *
   double *arg11 = (double *) 0 ;
   int arg12 ;
   int arg13 ;
+  int arg14 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 = 0 ;
@@ -19754,6 +19783,8 @@ SWIGINTERN PyObject *_wrap_comp_pspec(PyObject *SWIGUNUSEDPARM(self), PyObject *
   PyObject *array11 = NULL ;
   int val13 ;
   int ecode13 = 0 ;
+  int val14 ;
+  int ecode14 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -19762,8 +19793,9 @@ SWIGINTERN PyObject *_wrap_comp_pspec(PyObject *SWIGUNUSEDPARM(self), PyObject *
   PyObject * obj5 = 0 ;
   PyObject * obj6 = 0 ;
   PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOO:comp_pspec",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOO:comp_pspec",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_nmt_field, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "comp_pspec" "', argument " "1"" of type '" "nmt_field *""'"); 
@@ -19831,9 +19863,14 @@ SWIGINTERN PyObject *_wrap_comp_pspec(PyObject *SWIGUNUSEDPARM(self), PyObject *
     SWIG_exception_fail(SWIG_ArgError(ecode13), "in method '" "comp_pspec" "', argument " "13"" of type '" "int""'");
   } 
   arg13 = (int)(val13);
+  ecode14 = SWIG_AsVal_int(obj8, &val14);
+  if (!SWIG_IsOK(ecode14)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode14), "in method '" "comp_pspec" "', argument " "14"" of type '" "int""'");
+  } 
+  arg14 = (int)(val14);
   {
     try {
-      comp_pspec(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13);
+      comp_pspec(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13,arg14);
     }
     finally {
       SWIG_exception(SWIG_RuntimeError,nmt_error_message);

--- a/pymaster/namaster_wrap.c
+++ b/pymaster/namaster_wrap.c
@@ -3374,7 +3374,7 @@ void get_weight_list(nmt_binning_scheme *bins,int ibin,double *dout,int ndout)
 int get_lmax_py(int is_healpix,int nside,int nx,int ny,
 		double delta_phi,double delta_theta,double phi0,double theta0)
 {
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,(long)nside,nx,ny,
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,(long)nside,-1,nx,ny,
 						  delta_theta,delta_phi,phi0,theta0);
   int lmax=he_get_lmax(cs);
   free(cs);
@@ -3524,7 +3524,7 @@ void unbin_cl_flat(nmt_binning_scheme_flat *bins,
   free(cls_out);
 }
 
-nmt_field *field_alloc_new(int is_healpix,int nside,int nx,int ny,double delta_phi,
+nmt_field *field_alloc_new(int is_healpix,int nside,int lmax_sht,int nx,int ny,double delta_phi,
 			   double delta_theta,double phi0,double theta0,
 			   int npix_1,double *mask,
 			   int nmap_2,int npix_2,double *mps,
@@ -3549,7 +3549,7 @@ nmt_field *field_alloc_new(int is_healpix,int nside,int nx,int ny,double delta_p
   else
     asserting(npix_1==nx*ny);
 
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,nside_l,nx,ny,
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,nside_l,lmax_sht,nx,ny,
 						  delta_theta,delta_phi,phi0,theta0);
   asserting(nell3>he_get_lmax(cs));
 
@@ -3583,7 +3583,7 @@ nmt_field *field_alloc_new(int is_healpix,int nside,int nx,int ny,double delta_p
   return fl;
 }
 
-nmt_field *field_alloc_new_notemp(int is_healpix,int nside,int nx,int ny,double delta_phi,
+nmt_field *field_alloc_new_notemp(int is_healpix,int nside,int lmax_sht,int nx,int ny,double delta_phi,
 				  double delta_theta,double phi0,double theta0,
 				  int npix_1,double *mask,
 				  int nmap_2,int npix_2,double *mps,
@@ -3603,7 +3603,7 @@ nmt_field *field_alloc_new_notemp(int is_healpix,int nside,int nx,int ny,double 
   else
     asserting(npix_1==nx*ny);
 
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,nside_l,nx,ny,
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,nside_l,lmax_sht,nx,ny,
 						  delta_theta,delta_phi,phi0,theta0);
   asserting(nell3>he_get_lmax(cs));
 
@@ -3774,7 +3774,7 @@ void synfast_new(int is_healpix,int nside,int nx,int ny,double delta_phi,
       nmaps+=2;
   }
 
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,nside_l,nx,ny,
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(is_healpix,nside_l,-1,nx,ny,
 						  delta_theta,delta_phi,phi0,theta0);
   asserting(ncl2==nfields);
   asserting(ncl1==(nmaps*(nmaps+1))/2);
@@ -8338,6 +8338,58 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_curvedsky_info_lmax_sht_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  nmt_curvedsky_info *arg1 = (nmt_curvedsky_info *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:curvedsky_info_lmax_sht_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_nmt_curvedsky_info, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "curvedsky_info_lmax_sht_set" "', argument " "1"" of type '" "nmt_curvedsky_info *""'"); 
+  }
+  arg1 = (nmt_curvedsky_info *)(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "curvedsky_info_lmax_sht_set" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = (int)(val2);
+  if (arg1) (arg1)->lmax_sht = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_curvedsky_info_lmax_sht_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  nmt_curvedsky_info *arg1 = (nmt_curvedsky_info *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:curvedsky_info_lmax_sht_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_nmt_curvedsky_info, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "curvedsky_info_lmax_sht_get" "', argument " "1"" of type '" "nmt_curvedsky_info *""'"); 
+  }
+  arg1 = (nmt_curvedsky_info *)(argp1);
+  result = (int) ((arg1)->lmax_sht);
+  resultobj = SWIG_From_int((int)(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_curvedsky_info_nx_short_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nmt_curvedsky_info *arg1 = (nmt_curvedsky_info *) 0 ;
@@ -8837,10 +8889,11 @@ SWIGINTERN PyObject *_wrap_curvedsky_info_alloc(PyObject *SWIGUNUSEDPARM(self), 
   long arg2 ;
   int arg3 ;
   int arg4 ;
-  flouble arg5 ;
+  int arg5 ;
   flouble arg6 ;
   flouble arg7 ;
   flouble arg8 ;
+  flouble arg9 ;
   int val1 ;
   int ecode1 = 0 ;
   long val2 ;
@@ -8849,7 +8902,7 @@ SWIGINTERN PyObject *_wrap_curvedsky_info_alloc(PyObject *SWIGUNUSEDPARM(self), 
   int ecode3 = 0 ;
   int val4 ;
   int ecode4 = 0 ;
-  double val5 ;
+  int val5 ;
   int ecode5 = 0 ;
   double val6 ;
   int ecode6 = 0 ;
@@ -8857,6 +8910,8 @@ SWIGINTERN PyObject *_wrap_curvedsky_info_alloc(PyObject *SWIGUNUSEDPARM(self), 
   int ecode7 = 0 ;
   double val8 ;
   int ecode8 = 0 ;
+  double val9 ;
+  int ecode9 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -8865,9 +8920,10 @@ SWIGINTERN PyObject *_wrap_curvedsky_info_alloc(PyObject *SWIGUNUSEDPARM(self), 
   PyObject * obj5 = 0 ;
   PyObject * obj6 = 0 ;
   PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
   nmt_curvedsky_info *result = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOO:curvedsky_info_alloc",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOO:curvedsky_info_alloc",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8)) SWIG_fail;
   ecode1 = SWIG_AsVal_int(obj0, &val1);
   if (!SWIG_IsOK(ecode1)) {
     SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "curvedsky_info_alloc" "', argument " "1"" of type '" "int""'");
@@ -8888,11 +8944,11 @@ SWIGINTERN PyObject *_wrap_curvedsky_info_alloc(PyObject *SWIGUNUSEDPARM(self), 
     SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "curvedsky_info_alloc" "', argument " "4"" of type '" "int""'");
   } 
   arg4 = (int)(val4);
-  ecode5 = SWIG_AsVal_double(obj4, &val5);
+  ecode5 = SWIG_AsVal_int(obj4, &val5);
   if (!SWIG_IsOK(ecode5)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "curvedsky_info_alloc" "', argument " "5"" of type '" "flouble""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "curvedsky_info_alloc" "', argument " "5"" of type '" "int""'");
   } 
-  arg5 = (flouble)(val5);
+  arg5 = (int)(val5);
   ecode6 = SWIG_AsVal_double(obj5, &val6);
   if (!SWIG_IsOK(ecode6)) {
     SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "curvedsky_info_alloc" "', argument " "6"" of type '" "flouble""'");
@@ -8908,7 +8964,12 @@ SWIGINTERN PyObject *_wrap_curvedsky_info_alloc(PyObject *SWIGUNUSEDPARM(self), 
     SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "curvedsky_info_alloc" "', argument " "8"" of type '" "flouble""'");
   } 
   arg8 = (flouble)(val8);
-  result = (nmt_curvedsky_info *)nmt_curvedsky_info_alloc(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8);
+  ecode9 = SWIG_AsVal_double(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "curvedsky_info_alloc" "', argument " "9"" of type '" "flouble""'");
+  } 
+  arg9 = (flouble)(val9);
+  result = (nmt_curvedsky_info *)nmt_curvedsky_info_alloc(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9);
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_nmt_curvedsky_info, 0 |  0 );
   return resultobj;
 fail:
@@ -15855,26 +15916,27 @@ SWIGINTERN PyObject *_wrap_field_alloc_new(PyObject *SWIGUNUSEDPARM(self), PyObj
   int arg2 ;
   int arg3 ;
   int arg4 ;
-  double arg5 ;
+  int arg5 ;
   double arg6 ;
   double arg7 ;
   double arg8 ;
-  int arg9 ;
-  double *arg10 = (double *) 0 ;
-  int arg11 ;
+  double arg9 ;
+  int arg10 ;
+  double *arg11 = (double *) 0 ;
   int arg12 ;
-  double *arg13 = (double *) 0 ;
-  int arg14 ;
+  int arg13 ;
+  double *arg14 = (double *) 0 ;
   int arg15 ;
   int arg16 ;
-  double *arg17 = (double *) 0 ;
-  int arg18 ;
-  double *arg19 = (double *) 0 ;
-  int arg20 ;
+  int arg17 ;
+  double *arg18 = (double *) 0 ;
+  int arg19 ;
+  double *arg20 = (double *) 0 ;
   int arg21 ;
   int arg22 ;
-  double arg23 ;
-  int arg24 ;
+  int arg23 ;
+  double arg24 ;
+  int arg25 ;
   int val1 ;
   int ecode1 = 0 ;
   int val2 ;
@@ -15883,7 +15945,7 @@ SWIGINTERN PyObject *_wrap_field_alloc_new(PyObject *SWIGUNUSEDPARM(self), PyObj
   int ecode3 = 0 ;
   int val4 ;
   int ecode4 = 0 ;
-  double val5 ;
+  int val5 ;
   int ecode5 = 0 ;
   double val6 ;
   int ecode6 = 0 ;
@@ -15891,24 +15953,26 @@ SWIGINTERN PyObject *_wrap_field_alloc_new(PyObject *SWIGUNUSEDPARM(self), PyObj
   int ecode7 = 0 ;
   double val8 ;
   int ecode8 = 0 ;
-  PyArrayObject *array9 = NULL ;
-  int is_new_object9 = 0 ;
-  PyArrayObject *array11 = NULL ;
-  int is_new_object11 = 0 ;
-  PyArrayObject *array14 = NULL ;
-  int is_new_object14 = 0 ;
-  PyArrayObject *array18 = NULL ;
-  int is_new_object18 = 0 ;
-  int val20 ;
-  int ecode20 = 0 ;
+  double val9 ;
+  int ecode9 = 0 ;
+  PyArrayObject *array10 = NULL ;
+  int is_new_object10 = 0 ;
+  PyArrayObject *array12 = NULL ;
+  int is_new_object12 = 0 ;
+  PyArrayObject *array15 = NULL ;
+  int is_new_object15 = 0 ;
+  PyArrayObject *array19 = NULL ;
+  int is_new_object19 = 0 ;
   int val21 ;
   int ecode21 = 0 ;
   int val22 ;
   int ecode22 = 0 ;
-  double val23 ;
+  int val23 ;
   int ecode23 = 0 ;
-  int val24 ;
+  double val24 ;
   int ecode24 = 0 ;
+  int val25 ;
+  int ecode25 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -15926,9 +15990,10 @@ SWIGINTERN PyObject *_wrap_field_alloc_new(PyObject *SWIGUNUSEDPARM(self), PyObj
   PyObject * obj14 = 0 ;
   PyObject * obj15 = 0 ;
   PyObject * obj16 = 0 ;
+  PyObject * obj17 = 0 ;
   nmt_field *result = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOOOOOOOOO:field_alloc_new",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9,&obj10,&obj11,&obj12,&obj13,&obj14,&obj15,&obj16)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOOOOOOOOOO:field_alloc_new",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9,&obj10,&obj11,&obj12,&obj13,&obj14,&obj15,&obj16,&obj17)) SWIG_fail;
   ecode1 = SWIG_AsVal_int(obj0, &val1);
   if (!SWIG_IsOK(ecode1)) {
     SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "field_alloc_new" "', argument " "1"" of type '" "int""'");
@@ -15949,11 +16014,11 @@ SWIGINTERN PyObject *_wrap_field_alloc_new(PyObject *SWIGUNUSEDPARM(self), PyObj
     SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "field_alloc_new" "', argument " "4"" of type '" "int""'");
   } 
   arg4 = (int)(val4);
-  ecode5 = SWIG_AsVal_double(obj4, &val5);
+  ecode5 = SWIG_AsVal_int(obj4, &val5);
   if (!SWIG_IsOK(ecode5)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "field_alloc_new" "', argument " "5"" of type '" "double""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "field_alloc_new" "', argument " "5"" of type '" "int""'");
   } 
-  arg5 = (double)(val5);
+  arg5 = (int)(val5);
   ecode6 = SWIG_AsVal_double(obj5, &val6);
   if (!SWIG_IsOK(ecode6)) {
     SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "field_alloc_new" "', argument " "6"" of type '" "double""'");
@@ -15969,61 +16034,61 @@ SWIGINTERN PyObject *_wrap_field_alloc_new(PyObject *SWIGUNUSEDPARM(self), PyObj
     SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "field_alloc_new" "', argument " "8"" of type '" "double""'");
   } 
   arg8 = (double)(val8);
+  ecode9 = SWIG_AsVal_double(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "field_alloc_new" "', argument " "9"" of type '" "double""'");
+  } 
+  arg9 = (double)(val9);
   {
     npy_intp size[1] = {
       -1
     };
-    array9 = obj_to_array_contiguous_allow_conversion(obj8,
+    array10 = obj_to_array_contiguous_allow_conversion(obj9,
       NPY_DOUBLE,
-      &is_new_object9);
-    if (!array9 || !require_dimensions(array9, 1) ||
-      !require_size(array9, size, 1)) SWIG_fail;
-    arg9 = (int) array_size(array9,0);
-    arg10 = (double*) array_data(array9);
+      &is_new_object10);
+    if (!array10 || !require_dimensions(array10, 1) ||
+      !require_size(array10, size, 1)) SWIG_fail;
+    arg10 = (int) array_size(array10,0);
+    arg11 = (double*) array_data(array10);
   }
   {
     npy_intp size[2] = {
       -1, -1 
     };
-    array11 = obj_to_array_contiguous_allow_conversion(obj9,
+    array12 = obj_to_array_contiguous_allow_conversion(obj10,
       NPY_DOUBLE,
-      &is_new_object11);
-    if (!array11 || !require_dimensions(array11, 2) ||
-      !require_size(array11, size, 2)) SWIG_fail;
-    arg11 = (int) array_size(array11,0);
-    arg12 = (int) array_size(array11,1);
-    arg13 = (double*) array_data(array11);
+      &is_new_object12);
+    if (!array12 || !require_dimensions(array12, 2) ||
+      !require_size(array12, size, 2)) SWIG_fail;
+    arg12 = (int) array_size(array12,0);
+    arg13 = (int) array_size(array12,1);
+    arg14 = (double*) array_data(array12);
   }
   {
     npy_intp size[3] = {
       -1, -1, -1 
     };
-    array14 = obj_to_array_contiguous_allow_conversion(obj10, NPY_DOUBLE,
-      &is_new_object14);
-    if (!array14 || !require_dimensions(array14, 3) ||
-      !require_size(array14, size, 3)) SWIG_fail;
-    arg14 = (int) array_size(array14,0);
-    arg15 = (int) array_size(array14,1);
-    arg16 = (int) array_size(array14,2);
-    arg17 = (double*) array_data(array14);
+    array15 = obj_to_array_contiguous_allow_conversion(obj11, NPY_DOUBLE,
+      &is_new_object15);
+    if (!array15 || !require_dimensions(array15, 3) ||
+      !require_size(array15, size, 3)) SWIG_fail;
+    arg15 = (int) array_size(array15,0);
+    arg16 = (int) array_size(array15,1);
+    arg17 = (int) array_size(array15,2);
+    arg18 = (double*) array_data(array15);
   }
   {
     npy_intp size[1] = {
       -1
     };
-    array18 = obj_to_array_contiguous_allow_conversion(obj11,
+    array19 = obj_to_array_contiguous_allow_conversion(obj12,
       NPY_DOUBLE,
-      &is_new_object18);
-    if (!array18 || !require_dimensions(array18, 1) ||
-      !require_size(array18, size, 1)) SWIG_fail;
-    arg18 = (int) array_size(array18,0);
-    arg19 = (double*) array_data(array18);
+      &is_new_object19);
+    if (!array19 || !require_dimensions(array19, 1) ||
+      !require_size(array19, size, 1)) SWIG_fail;
+    arg19 = (int) array_size(array19,0);
+    arg20 = (double*) array_data(array19);
   }
-  ecode20 = SWIG_AsVal_int(obj12, &val20);
-  if (!SWIG_IsOK(ecode20)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode20), "in method '" "field_alloc_new" "', argument " "20"" of type '" "int""'");
-  } 
-  arg20 = (int)(val20);
   ecode21 = SWIG_AsVal_int(obj13, &val21);
   if (!SWIG_IsOK(ecode21)) {
     SWIG_exception_fail(SWIG_ArgError(ecode21), "in method '" "field_alloc_new" "', argument " "21"" of type '" "int""'");
@@ -16034,19 +16099,24 @@ SWIGINTERN PyObject *_wrap_field_alloc_new(PyObject *SWIGUNUSEDPARM(self), PyObj
     SWIG_exception_fail(SWIG_ArgError(ecode22), "in method '" "field_alloc_new" "', argument " "22"" of type '" "int""'");
   } 
   arg22 = (int)(val22);
-  ecode23 = SWIG_AsVal_double(obj15, &val23);
+  ecode23 = SWIG_AsVal_int(obj15, &val23);
   if (!SWIG_IsOK(ecode23)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode23), "in method '" "field_alloc_new" "', argument " "23"" of type '" "double""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode23), "in method '" "field_alloc_new" "', argument " "23"" of type '" "int""'");
   } 
-  arg23 = (double)(val23);
-  ecode24 = SWIG_AsVal_int(obj16, &val24);
+  arg23 = (int)(val23);
+  ecode24 = SWIG_AsVal_double(obj16, &val24);
   if (!SWIG_IsOK(ecode24)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode24), "in method '" "field_alloc_new" "', argument " "24"" of type '" "int""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode24), "in method '" "field_alloc_new" "', argument " "24"" of type '" "double""'");
   } 
-  arg24 = (int)(val24);
+  arg24 = (double)(val24);
+  ecode25 = SWIG_AsVal_int(obj17, &val25);
+  if (!SWIG_IsOK(ecode25)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode25), "in method '" "field_alloc_new" "', argument " "25"" of type '" "int""'");
+  } 
+  arg25 = (int)(val25);
   {
     try {
-      result = (nmt_field *)field_alloc_new(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13,arg14,arg15,arg16,arg17,arg18,arg19,arg20,arg21,arg22,arg23,arg24);
+      result = (nmt_field *)field_alloc_new(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13,arg14,arg15,arg16,arg17,arg18,arg19,arg20,arg21,arg22,arg23,arg24,arg25);
     }
     finally {
       SWIG_exception(SWIG_RuntimeError,nmt_error_message);
@@ -16054,53 +16124,53 @@ SWIGINTERN PyObject *_wrap_field_alloc_new(PyObject *SWIGUNUSEDPARM(self), PyObj
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_nmt_field, 0 |  0 );
   {
-    if (is_new_object9 && array9)
+    if (is_new_object10 && array10)
     {
-      Py_DECREF(array9); 
+      Py_DECREF(array10); 
     }
   }
   {
-    if (is_new_object11 && array11)
+    if (is_new_object12 && array12)
     {
-      Py_DECREF(array11); 
+      Py_DECREF(array12); 
     }
   }
   {
-    if (is_new_object14 && array14)
+    if (is_new_object15 && array15)
     {
-      Py_DECREF(array14); 
+      Py_DECREF(array15); 
     }
   }
   {
-    if (is_new_object18 && array18)
+    if (is_new_object19 && array19)
     {
-      Py_DECREF(array18); 
+      Py_DECREF(array19); 
     }
   }
   return resultobj;
 fail:
   {
-    if (is_new_object9 && array9)
+    if (is_new_object10 && array10)
     {
-      Py_DECREF(array9); 
+      Py_DECREF(array10); 
     }
   }
   {
-    if (is_new_object11 && array11)
+    if (is_new_object12 && array12)
     {
-      Py_DECREF(array11); 
+      Py_DECREF(array12); 
     }
   }
   {
-    if (is_new_object14 && array14)
+    if (is_new_object15 && array15)
     {
-      Py_DECREF(array14); 
+      Py_DECREF(array15); 
     }
   }
   {
-    if (is_new_object18 && array18)
+    if (is_new_object19 && array19)
     {
-      Py_DECREF(array18); 
+      Py_DECREF(array19); 
     }
   }
   return NULL;
@@ -16113,21 +16183,22 @@ SWIGINTERN PyObject *_wrap_field_alloc_new_notemp(PyObject *SWIGUNUSEDPARM(self)
   int arg2 ;
   int arg3 ;
   int arg4 ;
-  double arg5 ;
+  int arg5 ;
   double arg6 ;
   double arg7 ;
   double arg8 ;
-  int arg9 ;
-  double *arg10 = (double *) 0 ;
-  int arg11 ;
+  double arg9 ;
+  int arg10 ;
+  double *arg11 = (double *) 0 ;
   int arg12 ;
-  double *arg13 = (double *) 0 ;
-  int arg14 ;
-  double *arg15 = (double *) 0 ;
-  int arg16 ;
+  int arg13 ;
+  double *arg14 = (double *) 0 ;
+  int arg15 ;
+  double *arg16 = (double *) 0 ;
   int arg17 ;
   int arg18 ;
   int arg19 ;
+  int arg20 ;
   int val1 ;
   int ecode1 = 0 ;
   int val2 ;
@@ -16136,7 +16207,7 @@ SWIGINTERN PyObject *_wrap_field_alloc_new_notemp(PyObject *SWIGUNUSEDPARM(self)
   int ecode3 = 0 ;
   int val4 ;
   int ecode4 = 0 ;
-  double val5 ;
+  int val5 ;
   int ecode5 = 0 ;
   double val6 ;
   int ecode6 = 0 ;
@@ -16144,20 +16215,22 @@ SWIGINTERN PyObject *_wrap_field_alloc_new_notemp(PyObject *SWIGUNUSEDPARM(self)
   int ecode7 = 0 ;
   double val8 ;
   int ecode8 = 0 ;
-  PyArrayObject *array9 = NULL ;
-  int is_new_object9 = 0 ;
-  PyArrayObject *array11 = NULL ;
-  int is_new_object11 = 0 ;
-  PyArrayObject *array14 = NULL ;
-  int is_new_object14 = 0 ;
-  int val16 ;
-  int ecode16 = 0 ;
+  double val9 ;
+  int ecode9 = 0 ;
+  PyArrayObject *array10 = NULL ;
+  int is_new_object10 = 0 ;
+  PyArrayObject *array12 = NULL ;
+  int is_new_object12 = 0 ;
+  PyArrayObject *array15 = NULL ;
+  int is_new_object15 = 0 ;
   int val17 ;
   int ecode17 = 0 ;
   int val18 ;
   int ecode18 = 0 ;
   int val19 ;
   int ecode19 = 0 ;
+  int val20 ;
+  int ecode20 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -16173,9 +16246,10 @@ SWIGINTERN PyObject *_wrap_field_alloc_new_notemp(PyObject *SWIGUNUSEDPARM(self)
   PyObject * obj12 = 0 ;
   PyObject * obj13 = 0 ;
   PyObject * obj14 = 0 ;
+  PyObject * obj15 = 0 ;
   nmt_field *result = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOOOOOOO:field_alloc_new_notemp",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9,&obj10,&obj11,&obj12,&obj13,&obj14)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOOOOOOOO:field_alloc_new_notemp",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9,&obj10,&obj11,&obj12,&obj13,&obj14,&obj15)) SWIG_fail;
   ecode1 = SWIG_AsVal_int(obj0, &val1);
   if (!SWIG_IsOK(ecode1)) {
     SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "field_alloc_new_notemp" "', argument " "1"" of type '" "int""'");
@@ -16196,11 +16270,11 @@ SWIGINTERN PyObject *_wrap_field_alloc_new_notemp(PyObject *SWIGUNUSEDPARM(self)
     SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "field_alloc_new_notemp" "', argument " "4"" of type '" "int""'");
   } 
   arg4 = (int)(val4);
-  ecode5 = SWIG_AsVal_double(obj4, &val5);
+  ecode5 = SWIG_AsVal_int(obj4, &val5);
   if (!SWIG_IsOK(ecode5)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "field_alloc_new_notemp" "', argument " "5"" of type '" "double""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "field_alloc_new_notemp" "', argument " "5"" of type '" "int""'");
   } 
-  arg5 = (double)(val5);
+  arg5 = (int)(val5);
   ecode6 = SWIG_AsVal_double(obj5, &val6);
   if (!SWIG_IsOK(ecode6)) {
     SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "field_alloc_new_notemp" "', argument " "6"" of type '" "double""'");
@@ -16216,48 +16290,48 @@ SWIGINTERN PyObject *_wrap_field_alloc_new_notemp(PyObject *SWIGUNUSEDPARM(self)
     SWIG_exception_fail(SWIG_ArgError(ecode8), "in method '" "field_alloc_new_notemp" "', argument " "8"" of type '" "double""'");
   } 
   arg8 = (double)(val8);
+  ecode9 = SWIG_AsVal_double(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "field_alloc_new_notemp" "', argument " "9"" of type '" "double""'");
+  } 
+  arg9 = (double)(val9);
   {
     npy_intp size[1] = {
       -1
     };
-    array9 = obj_to_array_contiguous_allow_conversion(obj8,
+    array10 = obj_to_array_contiguous_allow_conversion(obj9,
       NPY_DOUBLE,
-      &is_new_object9);
-    if (!array9 || !require_dimensions(array9, 1) ||
-      !require_size(array9, size, 1)) SWIG_fail;
-    arg9 = (int) array_size(array9,0);
-    arg10 = (double*) array_data(array9);
+      &is_new_object10);
+    if (!array10 || !require_dimensions(array10, 1) ||
+      !require_size(array10, size, 1)) SWIG_fail;
+    arg10 = (int) array_size(array10,0);
+    arg11 = (double*) array_data(array10);
   }
   {
     npy_intp size[2] = {
       -1, -1 
     };
-    array11 = obj_to_array_contiguous_allow_conversion(obj9,
+    array12 = obj_to_array_contiguous_allow_conversion(obj10,
       NPY_DOUBLE,
-      &is_new_object11);
-    if (!array11 || !require_dimensions(array11, 2) ||
-      !require_size(array11, size, 2)) SWIG_fail;
-    arg11 = (int) array_size(array11,0);
-    arg12 = (int) array_size(array11,1);
-    arg13 = (double*) array_data(array11);
+      &is_new_object12);
+    if (!array12 || !require_dimensions(array12, 2) ||
+      !require_size(array12, size, 2)) SWIG_fail;
+    arg12 = (int) array_size(array12,0);
+    arg13 = (int) array_size(array12,1);
+    arg14 = (double*) array_data(array12);
   }
   {
     npy_intp size[1] = {
       -1
     };
-    array14 = obj_to_array_contiguous_allow_conversion(obj10,
+    array15 = obj_to_array_contiguous_allow_conversion(obj11,
       NPY_DOUBLE,
-      &is_new_object14);
-    if (!array14 || !require_dimensions(array14, 1) ||
-      !require_size(array14, size, 1)) SWIG_fail;
-    arg14 = (int) array_size(array14,0);
-    arg15 = (double*) array_data(array14);
+      &is_new_object15);
+    if (!array15 || !require_dimensions(array15, 1) ||
+      !require_size(array15, size, 1)) SWIG_fail;
+    arg15 = (int) array_size(array15,0);
+    arg16 = (double*) array_data(array15);
   }
-  ecode16 = SWIG_AsVal_int(obj11, &val16);
-  if (!SWIG_IsOK(ecode16)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode16), "in method '" "field_alloc_new_notemp" "', argument " "16"" of type '" "int""'");
-  } 
-  arg16 = (int)(val16);
   ecode17 = SWIG_AsVal_int(obj12, &val17);
   if (!SWIG_IsOK(ecode17)) {
     SWIG_exception_fail(SWIG_ArgError(ecode17), "in method '" "field_alloc_new_notemp" "', argument " "17"" of type '" "int""'");
@@ -16273,9 +16347,14 @@ SWIGINTERN PyObject *_wrap_field_alloc_new_notemp(PyObject *SWIGUNUSEDPARM(self)
     SWIG_exception_fail(SWIG_ArgError(ecode19), "in method '" "field_alloc_new_notemp" "', argument " "19"" of type '" "int""'");
   } 
   arg19 = (int)(val19);
+  ecode20 = SWIG_AsVal_int(obj15, &val20);
+  if (!SWIG_IsOK(ecode20)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode20), "in method '" "field_alloc_new_notemp" "', argument " "20"" of type '" "int""'");
+  } 
+  arg20 = (int)(val20);
   {
     try {
-      result = (nmt_field *)field_alloc_new_notemp(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13,arg14,arg15,arg16,arg17,arg18,arg19);
+      result = (nmt_field *)field_alloc_new_notemp(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13,arg14,arg15,arg16,arg17,arg18,arg19,arg20);
     }
     finally {
       SWIG_exception(SWIG_RuntimeError,nmt_error_message);
@@ -16283,41 +16362,41 @@ SWIGINTERN PyObject *_wrap_field_alloc_new_notemp(PyObject *SWIGUNUSEDPARM(self)
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_nmt_field, 0 |  0 );
   {
-    if (is_new_object9 && array9)
+    if (is_new_object10 && array10)
     {
-      Py_DECREF(array9); 
+      Py_DECREF(array10); 
     }
   }
   {
-    if (is_new_object11 && array11)
+    if (is_new_object12 && array12)
     {
-      Py_DECREF(array11); 
+      Py_DECREF(array12); 
     }
   }
   {
-    if (is_new_object14 && array14)
+    if (is_new_object15 && array15)
     {
-      Py_DECREF(array14); 
+      Py_DECREF(array15); 
     }
   }
   return resultobj;
 fail:
   {
-    if (is_new_object9 && array9)
+    if (is_new_object10 && array10)
     {
-      Py_DECREF(array9); 
+      Py_DECREF(array10); 
     }
   }
   {
-    if (is_new_object11 && array11)
+    if (is_new_object12 && array12)
     {
-      Py_DECREF(array11); 
+      Py_DECREF(array12); 
     }
   }
   {
-    if (is_new_object14 && array14)
+    if (is_new_object15 && array15)
     {
-      Py_DECREF(array14); 
+      Py_DECREF(array15); 
     }
   }
   return NULL;
@@ -20123,6 +20202,8 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"curvedsky_info_is_healpix_get", _wrap_curvedsky_info_is_healpix_get, METH_VARARGS, NULL},
 	 { (char *)"curvedsky_info_n_eq_set", _wrap_curvedsky_info_n_eq_set, METH_VARARGS, NULL},
 	 { (char *)"curvedsky_info_n_eq_get", _wrap_curvedsky_info_n_eq_get, METH_VARARGS, NULL},
+	 { (char *)"curvedsky_info_lmax_sht_set", _wrap_curvedsky_info_lmax_sht_set, METH_VARARGS, NULL},
+	 { (char *)"curvedsky_info_lmax_sht_get", _wrap_curvedsky_info_lmax_sht_get, METH_VARARGS, NULL},
 	 { (char *)"curvedsky_info_nx_short_set", _wrap_curvedsky_info_nx_short_set, METH_VARARGS, NULL},
 	 { (char *)"curvedsky_info_nx_short_get", _wrap_curvedsky_info_nx_short_get, METH_VARARGS, NULL},
 	 { (char *)"curvedsky_info_nx_set", _wrap_curvedsky_info_nx_set, METH_VARARGS, NULL},

--- a/pymaster/nmtlib.py
+++ b/pymaster/nmtlib.py
@@ -446,6 +446,10 @@ class curvedsky_info(_object):
     __swig_getmethods__["n_eq"] = _nmtlib.curvedsky_info_n_eq_get
     if _newclass:
         n_eq = _swig_property(_nmtlib.curvedsky_info_n_eq_get, _nmtlib.curvedsky_info_n_eq_set)
+    __swig_setmethods__["lmax_sht"] = _nmtlib.curvedsky_info_lmax_sht_set
+    __swig_getmethods__["lmax_sht"] = _nmtlib.curvedsky_info_lmax_sht_get
+    if _newclass:
+        lmax_sht = _swig_property(_nmtlib.curvedsky_info_lmax_sht_get, _nmtlib.curvedsky_info_lmax_sht_set)
     __swig_setmethods__["nx_short"] = _nmtlib.curvedsky_info_nx_short_set
     __swig_getmethods__["nx_short"] = _nmtlib.curvedsky_info_nx_short_get
     if _newclass:
@@ -495,8 +499,8 @@ def curvedsky_info_copy(cs_in):
     return _nmtlib.curvedsky_info_copy(cs_in)
 curvedsky_info_copy = _nmtlib.curvedsky_info_copy
 
-def curvedsky_info_alloc(is_healpix, nside, nx0, ny0, Dtheta, Dphi, phi0, theta0):
-    return _nmtlib.curvedsky_info_alloc(is_healpix, nside, nx0, ny0, Dtheta, Dphi, phi0, theta0)
+def curvedsky_info_alloc(is_healpix, nside, lmax_sht, nx0, ny0, Dtheta, Dphi, phi0, theta0):
+    return _nmtlib.curvedsky_info_alloc(is_healpix, nside, lmax_sht, nx0, ny0, Dtheta, Dphi, phi0, theta0)
 curvedsky_info_alloc = _nmtlib.curvedsky_info_alloc
 
 def diff_curvedsky_info(c1, c2):
@@ -1057,12 +1061,12 @@ def unbin_cl_flat(bins, ncl1, nell3, dout):
     return _nmtlib.unbin_cl_flat(bins, ncl1, nell3, dout)
 unbin_cl_flat = _nmtlib.unbin_cl_flat
 
-def field_alloc_new(is_healpix, nside, nx, ny, delta_phi, delta_theta, phi0, theta0, npix_1, nmap_2, ntmp_3, nell3, pure_e, pure_b, n_iter_mask_purify, tol_pinv, n_iter):
-    return _nmtlib.field_alloc_new(is_healpix, nside, nx, ny, delta_phi, delta_theta, phi0, theta0, npix_1, nmap_2, ntmp_3, nell3, pure_e, pure_b, n_iter_mask_purify, tol_pinv, n_iter)
+def field_alloc_new(is_healpix, nside, lmax_sht, nx, ny, delta_phi, delta_theta, phi0, theta0, npix_1, nmap_2, ntmp_3, nell3, pure_e, pure_b, n_iter_mask_purify, tol_pinv, n_iter):
+    return _nmtlib.field_alloc_new(is_healpix, nside, lmax_sht, nx, ny, delta_phi, delta_theta, phi0, theta0, npix_1, nmap_2, ntmp_3, nell3, pure_e, pure_b, n_iter_mask_purify, tol_pinv, n_iter)
 field_alloc_new = _nmtlib.field_alloc_new
 
-def field_alloc_new_notemp(is_healpix, nside, nx, ny, delta_phi, delta_theta, phi0, theta0, npix_1, nmap_2, nell3, pure_e, pure_b, n_iter_mask_purify, n_iter):
-    return _nmtlib.field_alloc_new_notemp(is_healpix, nside, nx, ny, delta_phi, delta_theta, phi0, theta0, npix_1, nmap_2, nell3, pure_e, pure_b, n_iter_mask_purify, n_iter)
+def field_alloc_new_notemp(is_healpix, nside, lmax_sht, nx, ny, delta_phi, delta_theta, phi0, theta0, npix_1, nmap_2, nell3, pure_e, pure_b, n_iter_mask_purify, n_iter):
+    return _nmtlib.field_alloc_new_notemp(is_healpix, nside, lmax_sht, nx, ny, delta_phi, delta_theta, phi0, theta0, npix_1, nmap_2, nell3, pure_e, pure_b, n_iter_mask_purify, n_iter)
 field_alloc_new_notemp = _nmtlib.field_alloc_new_notemp
 
 def field_alloc_new_flat(nx, ny, lx, ly, npix_1, nmap_2, ntmp_3, ncl1, pure_e, pure_b, tol_pinv):

--- a/pymaster/nmtlib.py
+++ b/pymaster/nmtlib.py
@@ -797,8 +797,8 @@ workspace_swigregister = _nmtlib.workspace_swigregister
 workspace_swigregister(workspace)
 
 
-def compute_coupling_matrix(fl1, fl2, bin, is_teb, niter):
-    return _nmtlib.compute_coupling_matrix(fl1, fl2, bin, is_teb, niter)
+def compute_coupling_matrix(fl1, fl2, bin, is_teb, niter, lmax_mask):
+    return _nmtlib.compute_coupling_matrix(fl1, fl2, bin, is_teb, niter, lmax_mask)
 compute_coupling_matrix = _nmtlib.compute_coupling_matrix
 
 def update_coupling_matrix(w, n_rows, new_matrix):
@@ -841,8 +841,8 @@ def compute_coupled_cell(fl1, fl2, cl_out):
     return _nmtlib.compute_coupled_cell(fl1, fl2, cl_out)
 compute_coupled_cell = _nmtlib.compute_coupled_cell
 
-def compute_power_spectra(fl1, fl2, bin, w0, cl_noise, cl_proposal, cl_out, niter):
-    return _nmtlib.compute_power_spectra(fl1, fl2, bin, w0, cl_noise, cl_proposal, cl_out, niter)
+def compute_power_spectra(fl1, fl2, bin, w0, cl_noise, cl_proposal, cl_out, niter, lmax_mask):
+    return _nmtlib.compute_power_spectra(fl1, fl2, bin, w0, cl_noise, cl_proposal, cl_out, niter, lmax_mask)
 compute_power_spectra = _nmtlib.compute_power_spectra
 class covar_workspace_flat(_object):
     __swig_setmethods__ = {}
@@ -1109,8 +1109,8 @@ def synfast_new_flat(nx, ny, lx, ly, nfields, seed, ncl1, ncl2, dout):
     return _nmtlib.synfast_new_flat(nx, ny, lx, ly, nfields, seed, ncl1, ncl2, dout)
 synfast_new_flat = _nmtlib.synfast_new_flat
 
-def comp_coupling_matrix(fl1, fl2, bin, is_teb, n_iter):
-    return _nmtlib.comp_coupling_matrix(fl1, fl2, bin, is_teb, n_iter)
+def comp_coupling_matrix(fl1, fl2, bin, is_teb, n_iter, lmax_mask):
+    return _nmtlib.comp_coupling_matrix(fl1, fl2, bin, is_teb, n_iter, lmax_mask)
 comp_coupling_matrix = _nmtlib.comp_coupling_matrix
 
 def comp_coupling_matrix_flat(fl1, fl2, bin, lmn_x, lmx_x, lmn_y, lmx_y, is_teb):
@@ -1201,8 +1201,8 @@ def couple_cell_py_flat(w, nell3, ncl1, dout):
     return _nmtlib.couple_cell_py_flat(w, nell3, ncl1, dout)
 couple_cell_py_flat = _nmtlib.couple_cell_py_flat
 
-def comp_pspec(fl1, fl2, bin, w0, ncl1, ncl2, dout, n_iter):
-    return _nmtlib.comp_pspec(fl1, fl2, bin, w0, ncl1, ncl2, dout, n_iter)
+def comp_pspec(fl1, fl2, bin, w0, ncl1, ncl2, dout, n_iter, lmax_mask):
+    return _nmtlib.comp_pspec(fl1, fl2, bin, w0, ncl1, ncl2, dout, n_iter, lmax_mask)
 comp_pspec = _nmtlib.comp_pspec
 
 def comp_pspec_flat(fl1, fl2, bin, w0, ncl1, nell3, ncl2, dout, lmn_x, lmx_x, lmn_y, lmx_y):

--- a/pymaster/workspaces.py
+++ b/pymaster/workspaces.py
@@ -30,7 +30,8 @@ class NmtWorkspace(object):
             self.wsp = None
         self.wsp = lib.read_workspace(fname)
 
-    def compute_coupling_matrix(self, fl1, fl2, bins, is_teb=False, n_iter=3):
+    def compute_coupling_matrix(self, fl1, fl2, bins, is_teb=False, n_iter=3,
+                                lmax_mask=-1):
         """
         Computes coupling matrix associated with the cross-power spectrum \
         of two NmtFields and an NmtBin binning scheme. Note that the mode \
@@ -43,12 +44,15 @@ class NmtWorkspace(object):
             (0-0,0-2,2-2) will be computed at the same time. In this case, \
             fl1 must be a spin-0 field and fl1 must be spin-2.
         :param n_iter: number of iterations when computing a_lms.
+        :param lmax_mask: maximum multipole for masks. If smaller than the \
+            maximum multipoles of the fields, it will be set to that.
         """
         if self.wsp is not None:
             lib.workspace_free(self.wsp)
             self.wsp = None
         self.wsp = lib.comp_coupling_matrix(fl1.fl, fl2.fl, bins.bin,
-                                            int(is_teb), int(n_iter))
+                                            int(is_teb), int(n_iter),
+                                            lmax_mask)
 
     def write_to(self, fname):
         """
@@ -473,7 +477,7 @@ def compute_coupled_cell_flat(f1, f2, b, ell_cut_x=[1., -1.],
 
 
 def compute_full_master(f1, f2, b, cl_noise=None, cl_guess=None,
-                        workspace=None, n_iter=3):
+                        workspace=None, n_iter=3, lmax_mask=-1):
     """
     Computes the full MASTER estimate of the power spectrum of two \
     fields (f1 and f2). This is equivalent to successively calling:
@@ -496,6 +500,8 @@ def compute_full_master(f1, f2, b, cl_noise=None, cl_guess=None,
         mode-coupling matrix and use the information encoded in this \
         object.
     :param n_iter: number of iterations when computing a_lms.
+    :param lmax_mask: maximum multipole for masks. If smaller than the \
+        maximum multipoles of the fields, it will be set to that.
     :return: set of decoupled bandpowers
     """
     if f1.fl.cs.n_eq != f2.fl.cs.n_eq:
@@ -515,11 +521,11 @@ def compute_full_master(f1, f2, b, cl_noise=None, cl_guess=None,
 
     if workspace is None:
         cl1d = lib.comp_pspec(f1.fl, f2.fl, b.bin, None, cln, clg,
-                              len(cln) * b.bin.n_bands, n_iter)
+                              len(cln) * b.bin.n_bands, n_iter, lmax_mask)
     else:
         cl1d = lib.comp_pspec(f1.fl, f2.fl, b.bin, workspace.wsp,
                               cln, clg, len(cln) * b.bin.n_bands,
-                              n_iter)
+                              n_iter, lmax_mask)
 
     clout = np.reshape(cl1d, [len(cln), b.bin.n_bands])
 

--- a/src/healpix_extra.c
+++ b/src/healpix_extra.c
@@ -126,6 +126,7 @@ flouble *he_read_map(char *fname,nmt_curvedsky_info *sky_info,int nfield) //DONE
   if(sky_info->is_healpix) {
     mp=he_read_HPX_map(fname,&(sky_info->n_eq),nfield);
     sky_info->npix=12*sky_info->n_eq*sky_info->n_eq;
+    sky_info->lmax_sht=he_get_largest_possible_lmax(sky_info);
   }
   else
     report_error(NMT_ERROR_NOT_IMPLEMENTED,"No IO functions for non-HEALPix pixelizations\n");
@@ -927,7 +928,7 @@ void he_alm2cl(fcomplex **alms_1,fcomplex **alms_2,int pol_1,int pol_2,flouble *
   }
 }
 
-int he_get_lmax(nmt_curvedsky_info *cs)
+int he_get_largest_possible_lmax(nmt_curvedsky_info *cs)
 {
   if(cs->is_healpix)
     return 3*cs->n_eq-1;
@@ -935,6 +936,11 @@ int he_get_lmax(nmt_curvedsky_info *cs)
     double dxmin=NMT_MIN(cs->Delta_phi,cs->Delta_theta);
     return (int)(M_PI/dxmin);
   }
+}
+
+int he_get_lmax(nmt_curvedsky_info *cs)
+{
+  return cs->lmax_sht;
 }
 
 void he_anafast(flouble **maps_1,flouble **maps_2,

--- a/src/healpix_extra.c
+++ b/src/healpix_extra.c
@@ -172,6 +172,7 @@ nmt_curvedsky_info *he_get_file_params(char *fname,int is_healpix,int *nfields,i
   if(cs->is_healpix) {
     he_get_HPX_file_params(fname,&(cs->n_eq),nfields,isnest);
     cs->npix=12*cs->n_eq*cs->n_eq;
+    cs->lmax_sht=3*cs->n_eq-1;
   }
   else
     report_error(NMT_ERROR_NOT_IMPLEMENTED,"No IO functions for non-HEALPix pixelizations\n");

--- a/src/namaster.h
+++ b/src/namaster.h
@@ -460,6 +460,7 @@ void nmt_purify_flat(nmt_field_flat *fl,flouble *mask,fcomplex **walm0,
 typedef struct {
   int is_healpix; //!< is this HEALPix pixelization?
   long n_eq; //!< equivalent of nside, number of pixels in the equatorial ring
+  int lmax_sht; //!< Maximum multipole to compute spherical harmonic transform
   int nx_short; //!< Number of grid points in the x dimension before completing the circle
   int nx; //!< Number of grid points in the phi dimension
   int ny; //!< Number of grid points in the theta dimension
@@ -496,6 +497,7 @@ nmt_curvedsky_info *nmt_curvedsky_info_copy(nmt_curvedsky_info *cs_in);
  * @return nmt_curvedsky_info struct.
  */
 nmt_curvedsky_info *nmt_curvedsky_info_alloc(int is_healpix,long nside,
+               int lmax_sht,
 					     int nx0,int ny0,flouble Dtheta,flouble Dphi,
 					     flouble phi0,flouble theta0);
 

--- a/src/namaster.h
+++ b/src/namaster.h
@@ -497,7 +497,7 @@ nmt_curvedsky_info *nmt_curvedsky_info_copy(nmt_curvedsky_info *cs_in);
  * @return nmt_curvedsky_info struct.
  */
 nmt_curvedsky_info *nmt_curvedsky_info_alloc(int is_healpix,long nside,
-               int lmax_sht,
+					     int lmax_sht,
 					     int nx0,int ny0,flouble Dtheta,flouble Dphi,
 					     flouble phi0,flouble theta0);
 
@@ -953,9 +953,11 @@ typedef struct {
  * @param bin nmt_binning_scheme defining the power spectrum bandpowers.
  * @param is_teb if !=0, all mode-coupling matrices (0-0,0-2,2-2) will be computed at the same time.
  * @param niter number of iterations when computing alms.
+ * @param lmax_mask maximum multipole to which the masks should be resolved. If smaller than the maximum multipole of fl1/fl2, it will be set to that.
+ * @return Newly allocated nmt_workspace structure containing the mode-coupling matrix.
  */
 nmt_workspace *nmt_compute_coupling_matrix(nmt_field *fl1,nmt_field *fl2,nmt_binning_scheme *bin,
-					   int is_teb,int niter);
+					   int is_teb,int niter,int lmax_mask);
 
 /**
  * @brief Updates the mode coupling matrix with a new one.Saves nmt_workspace structure to file
@@ -1111,13 +1113,14 @@ void nmt_compute_coupled_cell(nmt_field *fl1,nmt_field *fl2,flouble **cl_out);
           where \p ncls is defined above and \p nbpw is the number of bandpowers defined
 	  by \p bin.
  * @param niter number of iterations when computing alms.
+ * @param lmax_mask maximum multipole to which the masks should be resolved. If smaller than the maximum multipole of fl1/fl2, it will be set to that.
  * @return Newly allocated nmt_workspace structure containing the mode-coupling matrix
            if \p w0 is NULL (will return \p w0 otherwise).
  */
 nmt_workspace *nmt_compute_power_spectra(nmt_field *fl1,nmt_field *fl2,
 					 nmt_binning_scheme *bin,nmt_workspace *w0,
 					 flouble **cl_noise,flouble **cl_proposal,flouble **cl_out,
-					 int niter);
+					 int niter,int lmax_mask);
 
 /**
  * @brief Flat-sky Gaussian covariance matrix

--- a/src/nmt_field.c
+++ b/src/nmt_field.c
@@ -5,6 +5,7 @@ nmt_curvedsky_info *nmt_curvedsky_info_copy(nmt_curvedsky_info *cs_in)
   nmt_curvedsky_info *cs_out=my_malloc(sizeof(nmt_curvedsky_info));
   cs_out->is_healpix=cs_in->is_healpix;
   cs_out->n_eq=cs_in->n_eq;
+  cs_out->lmax_sht=cs_in->lmax_sht;
   cs_out->nx_short=cs_in->nx_short;
   cs_out->nx=cs_in->nx;
   cs_out->ny=cs_in->ny;
@@ -18,6 +19,7 @@ nmt_curvedsky_info *nmt_curvedsky_info_copy(nmt_curvedsky_info *cs_in)
 }
 
 nmt_curvedsky_info *nmt_curvedsky_info_alloc(int is_healpix,long nside,
+               int lmax_sht,
 					     int nx0,int ny0,flouble Dtheta,flouble Dphi,
 					     flouble phi0,flouble theta0)
 {
@@ -67,6 +69,12 @@ nmt_curvedsky_info *nmt_curvedsky_info_alloc(int is_healpix,long nside,
     cs->phi0=phi0;
     cs->theta0=theta0;
   }
+
+  // set lmax values, affects calls to he_get_lmax
+  if (lmax_sht == -1)
+    cs->lmax_sht=he_get_largest_possible_lmax(cs);
+  else
+    cs->lmax_sht=lmax_sht;
   
   return cs;
 }
@@ -487,7 +495,7 @@ nmt_field *nmt_field_read(int is_healpix,char *fname_mask,char *fname_maps,char 
   cs->is_healpix=is_healpix;
   cs_dum=my_malloc(sizeof(nmt_curvedsky_info));
   cs_dum->is_healpix=is_healpix;
-  
+
   //Read mask and compute nside, lmax etc.
   mask=he_read_map(fname_mask,cs,0);
   lmax=he_get_lmax(cs);

--- a/src/nmt_field.c
+++ b/src/nmt_field.c
@@ -19,7 +19,7 @@ nmt_curvedsky_info *nmt_curvedsky_info_copy(nmt_curvedsky_info *cs_in)
 }
 
 nmt_curvedsky_info *nmt_curvedsky_info_alloc(int is_healpix,long nside,
-               int lmax_sht,
+					     int lmax_sht,
 					     int nx0,int ny0,flouble Dtheta,flouble Dphi,
 					     flouble phi0,flouble theta0)
 {
@@ -71,7 +71,7 @@ nmt_curvedsky_info *nmt_curvedsky_info_alloc(int is_healpix,long nside,
   }
 
   // set lmax values, affects calls to he_get_lmax
-  if (lmax_sht == -1)
+  if (lmax_sht <= 0)
     cs->lmax_sht=he_get_largest_possible_lmax(cs);
   else
     cs->lmax_sht=lmax_sht;
@@ -101,12 +101,13 @@ flouble *nmt_extend_CAR_map(nmt_curvedsky_info *cs,flouble *map_in)
 int nmt_diff_curvedsky_info(nmt_curvedsky_info *c1, nmt_curvedsky_info *c2)
 {
   if(c1->is_healpix)
-    return (c2->is_healpix && (c1->n_eq==c2->n_eq));
+    return (c2->is_healpix && (c1->n_eq==c2->n_eq) && (c1->lmax_sht==c2->lmax_sht));
   else
     return ((!(c2->is_healpix)) && (c1->nx_short==c2->nx_short) && (c1->nx==c2->nx) && (c1->ny==c2->ny)
 	    && (fabs(c1->phi0-c2->phi0)<1e-6) && (fabs(c1->theta0-c2->theta0)<1e-6)
 	    && (fabs(c1->Delta_theta-c2->Delta_theta)<1e-6)
-	    && (fabs(c1->Delta_phi-c2->Delta_phi)<1e-6));
+	    && (fabs(c1->Delta_phi-c2->Delta_phi)<1e-6)
+	    && (c1->lmax_sht==c2->lmax_sht));
 }
   
 void nmt_field_free(nmt_field *fl)

--- a/src/nmt_main.c
+++ b/src/nmt_main.c
@@ -89,7 +89,7 @@ void run_master(nmt_field *fl1,nmt_field *fl2,
   }
   else {
     printf("Computing coupling matrix \n");
-    w=nmt_compute_coupling_matrix(fl1,fl2,bin,0,HE_NITER_DEFAULT);
+    w=nmt_compute_coupling_matrix(fl1,fl2,bin,0,HE_NITER_DEFAULT,-1);
     if(strcmp(fname_coupling,"none"))
       nmt_workspace_write(w,fname_coupling);
   }

--- a/src/nmt_mask.c
+++ b/src/nmt_mask.c
@@ -86,7 +86,7 @@ static void apodize_mask_CX(long nside,flouble *mask_in,flouble *mask_out,floubl
 static void apodize_mask_smooth(long nside,flouble *mask_in,flouble *mask_out,flouble aposize)
 {
   long npix=he_nside2npix(nside);
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1,-1);
   double aporad=aposize*M_PI/180;
   flouble *mask_dum=my_malloc(npix*sizeof(flouble));
   fcomplex *alms_dum=my_malloc(he_nalms(3*nside-1)*sizeof(fcomplex));

--- a/src/utils.h
+++ b/src/utils.h
@@ -492,9 +492,18 @@ void he_map2alm(nmt_curvedsky_info *cs,int lmax,int ntrans,int spin,flouble **ma
 void he_alm2cl(fcomplex **alms_1,fcomplex **alms_2,int pol_1,int pol_2,flouble **cls,int lmax);
 
 /**
- * @brief Get maximum multipole
+ * @brief Gets the multipole approximately corresponding to the Nyquist frequency.
  *
  * Computes the maximum multipole probed by a map.
+ * @param cs curved sky geometry info.
+ * @return maximum multipole.
+ */
+int he_get_largest_possible_lmax(nmt_curvedsky_info *cs);
+
+/**
+ * @brief Get maximum multipole allowed by sky geometry configuration.
+ *
+ * Returns the maximum multipole for a nmt_curvedsky_info.
  * @param cs curved sky geometry info.
  * @return maximum multipole.
  */

--- a/test/nmt_test_covar.c
+++ b/test/nmt_test_covar.c
@@ -5,7 +5,7 @@
 
 CTEST(nmt,covar_f_ell) {
   int ii;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1,-1);
   double *msk=he_read_map("test/benchmarks/msk.fits",cs,0);
   double *map=he_read_map("test/benchmarks/mps.fits",cs,0);
   nmt_workspace *w=nmt_workspace_read("test/benchmarks/bm_nc_np_w00.dat");
@@ -52,7 +52,7 @@ CTEST(nmt,covar_f_ell) {
 
 CTEST(nmt,covar) {
   int ii;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1,-1);
   double *msk=he_read_map("test/benchmarks/msk.fits",cs,0);
   double *map=he_read_map("test/benchmarks/mps.fits",cs,0);
   nmt_workspace *w=nmt_workspace_read("test/benchmarks/bm_nc_np_w00.dat");
@@ -108,7 +108,7 @@ CTEST(nmt,covar) {
   
 CTEST(nmt,covar_errors) {
   nmt_covar_workspace *cw=NULL;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1,-1);
   double *msk=he_read_map("test/benchmarks/msk.fits",cs,0);
   double *map=he_read_map("test/benchmarks/mps.fits",cs,0);
   nmt_field *f0=nmt_field_alloc_sph(cs,msk,0,&map,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);

--- a/test/nmt_test_field.c
+++ b/test/nmt_test_field.c
@@ -8,7 +8,7 @@ CTEST(nmt,field_alloc) {
   int ii,nmaps;
   double ntemp=5;
   long nside=128;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1,-1);
   long lmax=he_get_lmax(cs);
   long npix=he_nside2npix(nside);
   double **maps;
@@ -217,7 +217,7 @@ CTEST(nmt,field_read) {
 CTEST(nmt,field_synfast) {
   int ii,im1,im2,l,if1,if2;
   long nside=128;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1,-1);
   long lmax=he_get_lmax(cs);
   int nfields=3;
   int field_spins[3]={0,2,0};

--- a/test/nmt_test_field_car.c
+++ b/test/nmt_test_field_car.c
@@ -10,36 +10,36 @@ CTEST(nmt,curvedsky_errors)
   long nside=128;
   int nx=128,ny=128;
   double dth=M_PI/(3*nside),dph=M_PI/(3*nside);
-  nmt_curvedsky_info *cs_hpx_ref=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1);
-  nmt_curvedsky_info *cs_car_ref=nmt_curvedsky_info_alloc(0,-1,nx,ny,dth,dph,0,M_PI);
+  nmt_curvedsky_info *cs_hpx_ref=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs_car_ref=nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,dth,dph,0,M_PI);
 
   set_error_policy(THROW_ON_ERROR);
   cs=NULL;
-  try { cs=nmt_curvedsky_info_alloc(1,nside-1,-1,-1,-1,-1,-1,-1); } //Passing incorrect nside
+  try { cs=nmt_curvedsky_info_alloc(1,nside-1,-1,-1,-1,-1,-1,-1,-1); } //Passing incorrect nside
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(cs);
-  try { cs=nmt_curvedsky_info_alloc(0,-1,-nx,ny,dth,dph,0,M_PI/2); } //Passing incorrect CAR dimensions
+  try { cs=nmt_curvedsky_info_alloc(0,-1,-1,-nx,ny,dth,dph,0,M_PI/2); } //Passing incorrect CAR dimensions
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(cs);
-  try { cs=nmt_curvedsky_info_alloc(0,-1,nx,-ny,dth,dph,0,M_PI/2); }
+  try { cs=nmt_curvedsky_info_alloc(0,-1,-1,nx,-ny,dth,dph,0,M_PI/2); }
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(cs);
-  try { cs=nmt_curvedsky_info_alloc(0,-1,nx,ny,-dth,dph,0,M_PI/2); } //Wrong pixel sizes
+  try { cs=nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,-dth,dph,0,M_PI/2); } //Wrong pixel sizes
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(cs);
-  try { cs=nmt_curvedsky_info_alloc(0,-1,nx,ny,dth,-dph,0,M_PI/2); } //Wrong pixel sizes
+  try { cs=nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,dth,-dph,0,M_PI/2); } //Wrong pixel sizes
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(cs);
-  try { cs=nmt_curvedsky_info_alloc(0,-1,nx,ny,dth,dph,4*M_PI,M_PI/2); } //Wrong dimensions
+  try { cs=nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,dth,dph,4*M_PI,M_PI/2); } //Wrong dimensions
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(cs);
-  try { cs=nmt_curvedsky_info_alloc(0,-1,nx,ny,dth,dph,0,-0.1); }
+  try { cs=nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,dth,dph,0,-0.1); }
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(cs);
-  try { nmt_curvedsky_info_alloc(0,-1,nx,ny,dth,2*M_PI/(6*nside+0.5),0,M_PI); } //Pixel size is not CC-compliant
+  try { nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,dth,2*M_PI/(6*nside+0.5),0,M_PI); } //Pixel size is not CC-compliant
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(cs);
-  try { nmt_curvedsky_info_alloc(0,-1,nx,ny,M_PI/(3*nside+0.5),dph,0,M_PI); }
+  try { nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,M_PI/(3*nside+0.5),dph,0,M_PI); }
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(cs);
   set_error_policy(EXIT_ON_ERROR);
@@ -49,10 +49,10 @@ CTEST(nmt,curvedsky_errors)
 
   //Compare infos
   ASSERT_FALSE(nmt_diff_curvedsky_info(cs_hpx_ref,cs_car_ref)); //HPX vs CAR
-  cs=nmt_curvedsky_info_alloc(0,-1,nx,ny,dth,dph*2,0,M_PI/2);
+  cs=nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,dth,dph*2,0,M_PI/2);
   ASSERT_FALSE(nmt_diff_curvedsky_info(cs,cs_car_ref)); //Different pixel sizes
   free(cs);
-  cs=nmt_curvedsky_info_alloc(0,-1,nx,ny,dth,dph*(1+5E-10),0,M_PI); //Very similar pixel sizes
+  cs=nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,dth,dph*(1+5E-10),0,M_PI); //Very similar pixel sizes
   ASSERT_TRUE(nmt_diff_curvedsky_info(cs,cs_car_ref));
   free(cs);
 
@@ -87,7 +87,7 @@ CTEST(nmt,field_car_alloc) {
   double ntemp=5;
   int ny=384,nx=2*(ny-1);
   double dtheta=M_PI/(ny-1),dphi=dtheta;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(0,-1,nx,ny,dtheta,dphi,0.,M_PI);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,dtheta,dphi,0.,M_PI);
   long lmax=he_get_lmax(cs);
   long npix_short=nx*ny;
   double **maps;
@@ -266,7 +266,7 @@ CTEST(nmt,field_car_synfast) {
   int ii,im1,im2,l,if1,if2;
   int ny=384,nx=2*(ny-1);
   double dtheta=M_PI/(ny-1),dphi=dtheta;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(0,-1,nx,ny,dtheta,dphi,0.,M_PI);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,dtheta,dphi,0.,M_PI);
   long lmax=he_get_lmax(cs);
   int nfields=3;
   int field_spins[3]={0,2,0};

--- a/test/nmt_test_hpex.c
+++ b/test/nmt_test_hpex.c
@@ -7,7 +7,7 @@
 CTEST(nmt,he_synalm) {
   int ii,l;
   long nside=128;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1,-1);
   long lmax=3*nside-1;
   int nmaps=2;
   int ncls=nmaps*nmaps;
@@ -94,7 +94,7 @@ CTEST(nmt,he_alm2cl)
 {
   int ii;
   long nside=256;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1,-1);
   int lmax=3*nside-1;
   long npix=he_nside2npix(nside);
   double **maps=my_malloc(3*sizeof(double *));
@@ -148,7 +148,7 @@ CTEST(nmt,he_sht) {
   int ii;
   int nmaps=34;
   long nside=16;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1,-1);
   long lmax=3*nside-1;
   long npix=he_nside2npix(nside);
   double **maps=my_malloc(2*nmaps*sizeof(double *));
@@ -191,7 +191,7 @@ CTEST(nmt,he_sht) {
 
   //Test for one particular example
   nside=256;
-  free(cs); cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1);
+  free(cs); cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1,-1);
   npix=he_nside2npix(nside);
   free(maps);
   for(ii=0;ii<2;ii++)
@@ -232,10 +232,10 @@ CTEST(nmt,he_get_lmax) {
   long nside=256;
   int ny=384,nx=2*(ny-1);
   double dtheta=M_PI/(ny-1),dphi=dtheta;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1); 
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1,-1); 
   ASSERT_TRUE(he_get_lmax(cs)==3*nside-1);
   free(cs);
-  cs=nmt_curvedsky_info_alloc(0,-1,nx,ny,dtheta,dphi,0.,M_PI);
+  cs=nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,dtheta,dphi,0.,M_PI);
   ASSERT_TRUE(he_get_lmax(cs)==(int)(M_PI/dtheta));
   free(cs);
 }
@@ -244,10 +244,10 @@ CTEST(nmt,he_get_pix_area) {
   long nside=256;
   int ny=383,nx=2*(ny-1);
   double dtheta=M_PI/(ny-1),dphi=dtheta;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1); 
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1,-1); 
   ASSERT_DBL_NEAR_TOL(he_get_pix_area(cs,-1),M_PI/(3*nside*nside),1E-10);
   free(cs);
-  cs=nmt_curvedsky_info_alloc(0,-1,nx,ny,dtheta,dphi,0.,M_PI);
+  cs=nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,dtheta,dphi,0.,M_PI);
   ASSERT_DBL_NEAR_TOL(he_get_pix_area(cs,(ny-1)/2),dphi*dtheta,1E-10);
   free(cs);
 }
@@ -257,7 +257,7 @@ CTEST(nmt,he_sht_car) {
   int nmaps=34;
   int ny=384,nx=2*(ny-1);
   double dtheta=M_PI/(ny-1),dphi=dtheta;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(0,-1,nx,ny,dtheta,dphi,0.,M_PI);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,dtheta,dphi,0.,M_PI);
   long lmax=he_get_lmax(cs);
   long npix_short=nx*ny;
   double **maps=my_malloc(2*nmaps*sizeof(double *));
@@ -328,7 +328,7 @@ CTEST(nmt,he_io) {
 
   int ii;
   long nside=4;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1,-1);
   long npix=he_nside2npix(nside);
   ASSERT_EQUAL(npix,12*nside*nside);
 
@@ -439,7 +439,7 @@ CTEST(nmt,he_ringnum) {
 CTEST(nmt,he_algb) {
   int ii;
   long nside=128;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,nside,-1,-1,-1,-1,-1,-1,-1);
   long npix=he_nside2npix(nside);
   double *mp1=my_malloc(npix*sizeof(double));
   double *mp2=my_malloc(npix*sizeof(double));
@@ -468,7 +468,7 @@ CTEST(nmt,he_algb) {
   int ny=1383,nx=2*(ny-1);
   double dtheta=M_PI/(ny-1),dphi=dtheta;
   npix=ny*nx;
-  cs=nmt_curvedsky_info_alloc(0,-1,nx,ny,dtheta,dphi,0.,M_PI);
+  cs=nmt_curvedsky_info_alloc(0,-1,-1,nx,ny,dtheta,dphi,0.,M_PI);
   mp1=my_malloc(npix*sizeof(double));
   mp2=my_malloc(npix*sizeof(double));
   mpr=my_malloc(npix*sizeof(double));

--- a/test/nmt_test_master.c
+++ b/test/nmt_test_master.c
@@ -162,10 +162,10 @@ CTEST(nmt,master_teb_full) {
   //No contaminants
   f0=nmt_field_alloc_sph(cs,msk,0,mps0,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
   f2=nmt_field_alloc_sph(cs,msk,1,mps2,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
-  w_teb=nmt_compute_coupling_matrix(f0,f2,bin,1,HE_NITER_DEFAULT);
-  w00=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT);
-  w02=nmt_compute_coupling_matrix(f0,f2,bin,0,HE_NITER_DEFAULT);
-  w22=nmt_compute_coupling_matrix(f2,f2,bin,0,HE_NITER_DEFAULT);
+  w_teb=nmt_compute_coupling_matrix(f0,f2,bin,1,HE_NITER_DEFAULT,-1);
+  w00=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT,-1);
+  w02=nmt_compute_coupling_matrix(f0,f2,bin,0,HE_NITER_DEFAULT,-1);
+  w22=nmt_compute_coupling_matrix(f2,f2,bin,0,HE_NITER_DEFAULT,-1);
   nmt_compute_coupled_cell(f0,f0,&(cell[0]));
   nmt_compute_coupled_cell(f0,f2,&(cell[1]));
   nmt_compute_coupled_cell(f2,f2,&(cell[3]));
@@ -254,7 +254,7 @@ CTEST(nmt,master_22_full) {
   
   //No contaminants
   f2=nmt_field_alloc_sph(cs,msk,1,mps2,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
-  w22=nmt_compute_coupling_matrix(f2,f2,bin,0,HE_NITER_DEFAULT);
+  w22=nmt_compute_coupling_matrix(f2,f2,bin,0,HE_NITER_DEFAULT,-1);
   nmt_compute_coupled_cell(f2,f2,cell);
   nmt_decouple_cl_l(w22,cell,cell_noise,cell_deproj,cell_out);
   for(ii=0;ii<ncls;ii++)
@@ -264,7 +264,7 @@ CTEST(nmt,master_22_full) {
 
   //With purification
   f2=nmt_field_alloc_sph(cs,msk,1,mps2,0,NULL,NULL,0,1,3,1E-10,HE_NITER_DEFAULT);
-  w22=nmt_compute_coupling_matrix(f2,f2,bin,0,HE_NITER_DEFAULT);
+  w22=nmt_compute_coupling_matrix(f2,f2,bin,0,HE_NITER_DEFAULT,-1);
   nmt_compute_coupled_cell(f2,f2,cell);
   nmt_decouple_cl_l(w22,cell,cell_noise,cell_deproj,cell_out);
   for(ii=0;ii<ncls;ii++)
@@ -274,7 +274,7 @@ CTEST(nmt,master_22_full) {
 
   //With contaminants
   f2=nmt_field_alloc_sph(cs,msk,1,mps2,1,&tmp2,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
-  w22=nmt_compute_coupling_matrix(f2,f2,bin,0,HE_NITER_DEFAULT);
+  w22=nmt_compute_coupling_matrix(f2,f2,bin,0,HE_NITER_DEFAULT,-1);
   nmt_compute_coupled_cell(f2,f2,cell);
   nmt_compute_deprojection_bias(f2,f2,cell_signal,cell_deproj,HE_NITER_DEFAULT);
   for(ii=0;ii<ncls;ii++)
@@ -287,7 +287,7 @@ CTEST(nmt,master_22_full) {
 
   //With contaminants, with purification
   f2=nmt_field_alloc_sph(cs,msk,1,mps2,1,&tmp2,NULL,0,1,3,1E-10,HE_NITER_DEFAULT);
-  w22=nmt_compute_coupling_matrix(f2,f2,bin,0,HE_NITER_DEFAULT);
+  w22=nmt_compute_coupling_matrix(f2,f2,bin,0,HE_NITER_DEFAULT,-1);
   nmt_compute_coupled_cell(f2,f2,cell);
   nmt_compute_deprojection_bias(f2,f2,cell_signal,cell_deproj,HE_NITER_DEFAULT);
   for(ii=0;ii<ncls;ii++)
@@ -371,7 +371,7 @@ CTEST(nmt,master_02_full) {
   //No contaminants
   f0=nmt_field_alloc_sph(cs,msk,0,mps0,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
   f2=nmt_field_alloc_sph(cs,msk,1,mps2,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
-  w02=nmt_compute_coupling_matrix(f0,f2,bin,0,HE_NITER_DEFAULT);
+  w02=nmt_compute_coupling_matrix(f0,f2,bin,0,HE_NITER_DEFAULT,-1);
   nmt_compute_coupled_cell(f0,f2,cell);
   nmt_decouple_cl_l(w02,cell,cell_noise,cell_deproj,cell_out);
   for(ii=0;ii<ncls;ii++)
@@ -383,7 +383,7 @@ CTEST(nmt,master_02_full) {
   //With purification
   f0=nmt_field_alloc_sph(cs,msk,0,mps0,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
   f2=nmt_field_alloc_sph(cs,msk,1,mps2,0,NULL,NULL,0,1,3,1E-10,HE_NITER_DEFAULT);
-  w02=nmt_compute_coupling_matrix(f0,f2,bin,0,HE_NITER_DEFAULT);
+  w02=nmt_compute_coupling_matrix(f0,f2,bin,0,HE_NITER_DEFAULT,-1);
   nmt_compute_coupled_cell(f0,f2,cell);
   nmt_decouple_cl_l(w02,cell,cell_noise,cell_deproj,cell_out);
   for(ii=0;ii<ncls;ii++)
@@ -395,7 +395,7 @@ CTEST(nmt,master_02_full) {
   //With contaminants
   f0=nmt_field_alloc_sph(cs,msk,0,mps0,1,&tmp0,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
   f2=nmt_field_alloc_sph(cs,msk,1,mps2,1,&tmp2,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
-  w02=nmt_compute_coupling_matrix(f0,f2,bin,0,HE_NITER_DEFAULT);
+  w02=nmt_compute_coupling_matrix(f0,f2,bin,0,HE_NITER_DEFAULT,-1);
   nmt_compute_coupled_cell(f0,f2,cell);
   nmt_compute_deprojection_bias(f0,f2,cell_signal,cell_deproj,HE_NITER_DEFAULT);
   for(ii=0;ii<ncls;ii++)
@@ -410,7 +410,7 @@ CTEST(nmt,master_02_full) {
   //With contaminants, with purification
   f0=nmt_field_alloc_sph(cs,msk,0,mps0,1,&tmp0,NULL,0,1,3,1E-10,HE_NITER_DEFAULT);
   f2=nmt_field_alloc_sph(cs,msk,1,mps2,1,&tmp2,NULL,0,1,3,1E-10,HE_NITER_DEFAULT);
-  w02=nmt_compute_coupling_matrix(f0,f2,bin,0,HE_NITER_DEFAULT);
+  w02=nmt_compute_coupling_matrix(f0,f2,bin,0,HE_NITER_DEFAULT,-1);
   nmt_compute_coupled_cell(f0,f2,cell);
   nmt_compute_deprojection_bias(f0,f2,cell_signal,cell_deproj,HE_NITER_DEFAULT);
   for(ii=0;ii<ncls;ii++)
@@ -491,7 +491,7 @@ CTEST(nmt,master_00_full) {
   
   //No contaminants
   f0=nmt_field_alloc_sph(cs,msk,0,&mps,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
-  w00=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT);
+  w00=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT,-1);
   nmt_compute_coupled_cell(f0,f0,cell);
   nmt_decouple_cl_l(w00,cell,cell_noise,cell_deproj,cell_out);
   for(ii=0;ii<ncls;ii++)
@@ -501,7 +501,7 @@ CTEST(nmt,master_00_full) {
 
   //With contaminants
   f0=nmt_field_alloc_sph(cs,msk,0,&mps,1,&tmp,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
-  w00=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT);
+  w00=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT,-1);
   nmt_compute_coupled_cell(f0,f0,cell);
   nmt_compute_deprojection_bias(f0,f0,cell_signal,cell_deproj,HE_NITER_DEFAULT);
   for(ii=0;ii<ncls;ii++)
@@ -570,7 +570,7 @@ CTEST(nmt,master_00_f_ell) {
   
   //No contaminants
   f0=nmt_field_alloc_sph(cs,msk,0,&mps,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
-  w00=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT);
+  w00=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT,-1);
   nmt_compute_coupled_cell(f0,f0,cell);
   nmt_decouple_cl_l(w00,cell,cell_noise,cell_deproj,cell_out);
   for(ii=0;ii<bin->n_bands;ii++) { //Rough correction for ell-dependent prefactor
@@ -605,7 +605,7 @@ CTEST(nmt,bandpower_windows) {
   long lmax=he_get_lmax(cs);
   nmt_binning_scheme *bin=nmt_bins_constant(20,lmax,0);
   nmt_field *f0=nmt_field_alloc_sph(cs,msk,0,&mpt,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
-  nmt_workspace *w=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT);
+  nmt_workspace *w=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT,-1);
 
   double *cls_in=malloc((lmax+1)*sizeof(double));
   double *cls_zero=calloc(lmax+1,sizeof(double));
@@ -673,28 +673,28 @@ CTEST(nmt,master_errors) {
   ASSERT_NULL(w);
   //Wrong bins
   bin=nmt_bins_constant(20,6*cs->n_eq-1,0);
-  try { w=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT); }
+  try { w=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT,-1); }
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(w);
   nmt_bins_free(bin);
   //Mismatching resolutions
   bin=nmt_bins_constant(20,lmax,0);
-  try { w=nmt_compute_coupling_matrix(f0,f0b,bin,0,HE_NITER_DEFAULT); }
+  try { w=nmt_compute_coupling_matrix(f0,f0b,bin,0,HE_NITER_DEFAULT,-1); }
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(w);
   //Wrong fields for teb
-  try { w=nmt_compute_coupling_matrix(f0,f0,bin,1,HE_NITER_DEFAULT); }
+  try { w=nmt_compute_coupling_matrix(f0,f0,bin,1,HE_NITER_DEFAULT,-1); }
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(w);
   //Try through nmt_compute_power_spectra
-  try { w=nmt_compute_power_spectra(f0,f0b,bin,NULL,NULL,NULL,NULL,HE_NITER_DEFAULT); }
+  try { w=nmt_compute_power_spectra(f0,f0b,bin,NULL,NULL,NULL,NULL,HE_NITER_DEFAULT,-1); }
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(w);
   //nmt_compute_power_spectra with mis-matching input workspace
-  w=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT);
+  w=nmt_compute_coupling_matrix(f0,f0,bin,0,HE_NITER_DEFAULT,-1);
   nmt_bins_free(bin);
   bin=nmt_bins_constant(20,3*cs->n_eq/2-1,0);
-  try { wb=nmt_compute_power_spectra(f0b,f0b,bin,w,NULL,NULL,NULL,HE_NITER_DEFAULT); }
+  try { wb=nmt_compute_power_spectra(f0b,f0b,bin,w,NULL,NULL,NULL,HE_NITER_DEFAULT,-1); }
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(wb);
   //nmt_update_coupling_matrix with wrong input

--- a/test/nmt_test_master.c
+++ b/test/nmt_test_master.c
@@ -9,7 +9,7 @@ CTEST(nmt,master_bias_uncorr) {
   double prefac,f_fac;
   long ipix,npix;
   nmt_field *f0,*f2;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1,-1);
   double **mps0=my_malloc(sizeof(double *));
   double **mps2=my_malloc(2*sizeof(double *));
   double **tmp0=my_malloc(sizeof(double *));
@@ -119,7 +119,7 @@ CTEST(nmt,master_teb_full) {
   long ipix;
   nmt_field *f0,*f2;
   nmt_workspace *w_teb,*w00,*w02,*w22;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1,-1);
   double **mps0=my_malloc(sizeof(double *));
   double **mps2=my_malloc(2*sizeof(double *));
   double *msk=he_read_map("test/benchmarks/msk.fits",cs,0);
@@ -213,7 +213,7 @@ CTEST(nmt,master_22_full) {
   long ipix;
   nmt_field *f2;
   nmt_workspace *w22;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1,-1);
   double **mps2=my_malloc(2*sizeof(double *));
   double **tmp2=my_malloc(2*sizeof(double *));
   double *msk=he_read_map("test/benchmarks/msk.fits",cs,0);
@@ -325,7 +325,7 @@ CTEST(nmt,master_02_full) {
   long ipix;
   nmt_field *f0,*f2;
   nmt_workspace *w02;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1,-1);
   double **mps0=my_malloc(sizeof(double *));
   double **mps2=my_malloc(2*sizeof(double *));
   double **tmp0=my_malloc(sizeof(double *));
@@ -453,7 +453,7 @@ CTEST(nmt,master_00_full) {
   long ipix;
   nmt_field *f0;
   nmt_workspace *w00;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1,-1);
   double *mps=he_read_map("test/benchmarks/mps.fits",cs,0);
   double **tmp=my_malloc(sizeof(double *));
   double *msk=he_read_map("test/benchmarks/msk.fits",cs,0);
@@ -536,7 +536,7 @@ CTEST(nmt,master_00_f_ell) {
   long ipix;
   nmt_field *f0;
   nmt_workspace *w00;
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1,-1);
   double *mps=he_read_map("test/benchmarks/mps.fits",cs,0);
   double *msk=he_read_map("test/benchmarks/msk.fits",cs,0);
   long lmax=he_get_lmax(cs);
@@ -599,7 +599,7 @@ CTEST(nmt,master_00_f_ell) {
 }
 
 CTEST(nmt,bandpower_windows) {
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1,-1);
   double *mpt=he_read_map("test/benchmarks/mps.fits",cs,0);
   double *msk=he_read_map("test/benchmarks/msk.fits",cs,0);
   long lmax=he_get_lmax(cs);
@@ -653,13 +653,14 @@ CTEST(nmt,bandpower_windows) {
 }  
 
 CTEST(nmt,master_errors) {
-  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs=nmt_curvedsky_info_alloc(1,1,-1,-1,-1,-1,-1,-1,-1);
   double *mpt=he_read_map("test/benchmarks/mps.fits",cs,0);
   double *msk=he_read_map("test/benchmarks/msk.fits",cs,0);
   long lmax=he_get_lmax(cs);
+  
   nmt_binning_scheme *bin;
   nmt_workspace *w=NULL,*wb=NULL;
-  nmt_curvedsky_info *cs_half=nmt_curvedsky_info_alloc(1,cs->n_eq/2,-1,-1,-1,-1,-1,-1);
+  nmt_curvedsky_info *cs_half=nmt_curvedsky_info_alloc(1,cs->n_eq/2,-1,-1,-1,-1,-1,-1,-1);
 
   nmt_field *f0=nmt_field_alloc_sph(cs,msk,0,&mpt,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);
   nmt_field *f0b=nmt_field_alloc_sph(cs_half,msk,0,&mpt,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT);


### PR DESCRIPTION
This first commit sets the global lmax parameter when allocating for `nmt_curvedsky_info`, the sky geometry object. Setting `lmax_sht=-1` reproduces the old behavior of using the largest possible lmax. This is set in the `NmtField` on the python side, and workspaces inherit `nmt_curvedsky_info` from their fields.

Tests on four splits with actual ACT maps and masks suggest a factor of 2 in performance, but @damonge has some concerns about the mask structure, for which we'll need a second knob.