### PR TITLE
Rollback gitlab

### DIFF
--- a/NERSC_installation.md
+++ b/NERSC_installation.md
@@ -37,33 +37,11 @@ Note that the above assumes you'll install all C dependencies below into `$HOME/
 
 ## 2 Install libsharp
 libsharp is a C library for spherical harmonic transforms. Follow these steps to install it before moving on to NaMaster.
-There are three different versions of libsharp you may want to install:
-1. The github version from [its github repository](https://github.com/dagss/libsharp).
-2. The gitlab version (latest) from [gitlab](https://gitlab.mpcdf.mpg.de/mtr/libsharp).
-3. The version shipped with HEALPix.
-We provide instructions for each of these here:
-
-### 2.1 The github version (default)
 1. Download libsharp from its github repository and unzip the file.
 2. From the libsharp folder run `autoreconf -i`, which will generate a `configure` file.
 3. Run `./configure --enable-pic` and `make`
 4. Create three directories: `bin`, `lib` and `include` in your home directory (unless they're already there). E.g. `mkdir $HOME/bin` etc.
 5. Move the contents of `auto/bin`, `auto/lib` and `auto/include` to the corresponding folders you just created in your home directory by hand.
-
-### 2.2 The gitlab version
-1. Download libsharp from its github repository and unzip the file.
-2. From the libsharp folder run `autoreconf -i`, which will generate a `configure` file.
-3. Follow the instruction on the `COMPILE` file to run `configure`. The command `CC=cc CFLAGS="-std=c99 -O3 -ffast-math" ./configure --prefix=$HOME` should work.
-4. After running the `configure` script, type `make` and `make install`. To check that the installation worked run the test suite typing
-```
-export CRAYPE_LINK_TYPE=dynamic
-export XTPE_LINK_TYPE=dynamic
-make check
-```
-5. Finally, copy the header file in `pocketfft/pocketfft.h` to `$HOME/include` by hand, since NaMaster needs to use it.
-
-### 2.3 The version shipped with HEALPix
-Instructions provided in section 5 below.
 
 ## 3 Install cfitsio
 1. Go to https://heasarc.gsfc.nasa.gov/fitsio/ and download the latest tarball. Untar it and go into its root directory.
@@ -83,7 +61,6 @@ make install
 2. Run `./configure` and follow the instructions to install the C package (option 2). Make sure to mark `cc` as your preferred compiler. You don't need the shared library or the suggested modifications to your shell profile.
 3. Run `make c-all`
 4. Move (by hand!) the contents of `./lib/` and `./include/` to their corresponding equivalents in your `$HOME`.
-5. If you want to use the libsharp version distributed with HEALPix with NaMaster you need to
 download HEALPix version >=3.50 and configure the C++ package. For this purpose we suggest to use the GNU programming environment
 ```
 module swap PrgEnv-intel PrgEnv-gnu
@@ -103,6 +80,6 @@ Once all the above has been installed, download or clone NaMaster from its [gith
 export CRAYPE_LINK_TYPE=dynamic
 export XTPE_LINK_TYPE=dynamic
 ```
-2. Run `./configure --prefix=$HOME`, `make` and `make install`. If you want to link NaMaster to the libsharp library distributed with HEALPix then run `./configure` adding the `--enable-libsharp_healpix` flag. If you want to link NaMaster to its gitlab version, add the `--enable-libsharp_gitlab` flag instead. If none of these are passed, it will be assumed that you have installed the github version of libsharp.
-3. Run `LDSHARED="cc -shared" CC=cc python setup.py install --user` (note that the `LDSHARED` instruction is there to force setuptools to use the right linker at NERSC, but I've never needed it on other machines). This will install the python module, `pymaster`. As before, if you're linking with the healpix or gitlab versions of libsharp, then add `--enable-libsharp_healpix` or `--enable-libsharp_gitlab` to the `setup.py` command.
+2. Run `./configure --prefix=$HOME`, `make` and `make install`.
+3. Run `LDSHARED="cc -shared" CC=cc python setup.py install --user` (note that the `LDSHARED` instruction is there to force setuptools to use the right linker at NERSC, but I've never needed it on other machines). This will install the python module, `pymaster`.
 4. To check that the installation worked, go to the `test` directory and run `python check.py`. If you see a bunch of small numbers and plots coming up after a while (and no errors occurred), you can congratulate yourself: you have a working version of NaMaster on NERSC!

--- a/NERSC_installation.md
+++ b/NERSC_installation.md
@@ -18,6 +18,8 @@ pip install --user healpy
 ```
 
 ## 1 Prepare to compile the C libraries
+All the instructions below assume that you're using the Intel compilers on NERSC.
+
 You'll want to run the following in order to prepare your environment to install NaMaster:
 ```
 module load gsl/2.5
@@ -61,10 +63,6 @@ make install
 2. Run `./configure` and follow the instructions to install the C package (option 2). Make sure to mark `cc` as your preferred compiler. You don't need the shared library or the suggested modifications to your shell profile.
 3. Run `make c-all`
 4. Move (by hand!) the contents of `./lib/` and `./include/` to their corresponding equivalents in your `$HOME`.
-download HEALPix version >=3.50 and configure the C++ package. For this purpose we suggest to use the GNU programming environment
-```
-module swap PrgEnv-intel PrgEnv-gnu
-```
  Run `./configure` and follow the instructions to install the C++ package. We suggest to use the `optimized_gcc`option. Do not forget to add to your environment the HEALPix C++ related paths. If you used the optimized_gcc configuration these would be
 ```
 export LDFLAGS+=" -L$HEALPIX/src/cxx/optimized_gcc/lib/"


### PR DESCRIPTION
We started supporting the gitlab version of libsharp, but this seems to be still under development and changing all the time, so I'll stop supporting it until it becomes more stable.
