### PR TITLE
Healpy dtype

### DIFF
--- a/pymaster/tests/test_covar.py
+++ b/pymaster/tests/test_covar.py
@@ -16,9 +16,11 @@ class CovarTester(object):
         self.nside = 64
         self.nlb = 16
         self.npix = hp.nside2npix(self.nside)
-        msk = hp.read_map("test/benchmarks/msk.fits", verbose=False)
+        msk = hp.read_map("test/benchmarks/msk.fits", verbose=False,
+                          dtype=float)
         mps = np.array(hp.read_map("test/benchmarks/mps.fits",
-                                   verbose=False, field=[0, 1, 2]))
+                                   verbose=False, field=[0, 1, 2],
+                                   dtype=float))
         self.b = nmt.NmtBin.from_nside_linear(self.nside, self.nlb)
         self.f0 = nmt.NmtField(msk, [mps[0]])
         self.f2 = nmt.NmtField(msk, [mps[1], mps[2]])

--- a/pymaster/tests/test_field.py
+++ b/pymaster/tests/test_field.py
@@ -69,10 +69,12 @@ def test_field_get_alms():
 def test_field_masked():
     nside = 64
     b = nmt.NmtBin.from_nside_linear(nside, 16)
-    msk = hp.read_map("test/benchmarks/msk.fits", verbose=False)
+    msk = hp.read_map("test/benchmarks/msk.fits", verbose=False,
+                      dtype=float)
     mps = np.array(hp.read_map("test/benchmarks/mps.fits",
                                verbose=False,
-                               field=[0, 1, 2]))
+                               field=[0, 1, 2],
+                               dtype=float))
     mps_msk = np.array([m * msk for m in mps])
     f0 = nmt.NmtField(msk, [mps[0]])
     f0_msk = nmt.NmtField(msk, [mps_msk[0]],

--- a/pymaster/tests/test_master.py
+++ b/pymaster/tests/test_master.py
@@ -18,16 +18,16 @@ class WorkspaceTester(object):
         self.lmax = 3*self.nside-1
         self.npix = int(hp.nside2npix(self.nside))
         self.msk = hp.read_map("test/benchmarks/msk.fits",
-                               verbose=False)
+                               verbose=False, dtype=float)
         self.mps = np.array(hp.read_map("test/benchmarks/mps.fits",
                                         verbose=False,
-                                        field=[0, 1, 2]))
+                                        field=[0, 1, 2], dtype=float))
         self.mps_s1 = np.array(hp.read_map("test/benchmarks/mps_sp1.fits",
                                            verbose=False,
-                                           field=[0, 1, 2]))
+                                           field=[0, 1, 2], dtype=float))
         self.tmp = np.array(hp.read_map("test/benchmarks/tmp.fits",
                                         verbose=False,
-                                        field=[0, 1, 2]))
+                                        field=[0, 1, 2], dtype=float))
         self.b = nmt.NmtBin.from_nside_linear(self.nside, self.nlb)
         self.f0 = nmt.NmtField(self.msk,
                                [self.mps[0]])  # Original nside


### PR DESCRIPTION
We need to specify `dtype=float` when calling `hp.read_map` to ensure maps get read as double precision arrays.