### PR TITLE
Faster spin-0 covariances

### DIFF
--- a/pymaster/covariance.py
+++ b/pymaster/covariance.py
@@ -21,23 +21,27 @@ class NmtCovarianceWorkspace(object):
                 lib.covar_workspace_free(self.wsp)
             self.wsp = None
 
-    def read_from(self, fname):
+    def read_from(self, fname, force_spin0_only=False):
         """
         Reads the contents of an NmtCovarianceWorkspace object \
         from a FITS file.
 
         :param str fname: input file name
+        :param bool force_spin0_only: if `True`, only spin-0 \
+            combinations will be read and stored.
         """
         if self.wsp is not None:
             lib.covar_workspace_free(self.wsp)
             self.wsp = None
-        self.wsp = lib.read_covar_workspace(fname)
+        self.wsp = lib.read_covar_workspace(fname,
+                                            int(force_spin0_only))
 
     def compute_coupling_coefficients(self, fla1, fla2,
                                       flb1=None, flb2=None,
                                       lmax=None, n_iter=3,
                                       l_toeplitz=-1,
-                                      l_exact=-1, dl_band=-1):
+                                      l_exact=-1, dl_band=-1,
+                                      spin0_only=False):
         """
         Computes coupling coefficients of the Gaussian covariance \
         between the power spectra of two pairs of NmtField objects \
@@ -63,6 +67,8 @@ class NmtCovarianceWorkspace(object):
         :param dl_band: if `l_toeplitz>0`, this quantity corresponds to \
             Delta ell_band in Fig. 3 of Louis et al. 2020.  Ignored if \
             `l_toeplitz<=0`.
+        :spin0_only: if `True`, only spin-0 combinations of the MCMs will \
+            be computed and stored.
         """
         if flb1 is None:
             flb1 = fla1
@@ -84,7 +90,8 @@ class NmtCovarianceWorkspace(object):
         _toeplitz_sanity(l_toeplitz, l_exact, dl_band, lmax, fla1, flb1)
         self.wsp = lib.covar_workspace_init_py(fla1.fl, fla2.fl, flb1.fl,
                                                flb2.fl, lmax, n_iter,
-                                               l_toeplitz, l_exact, dl_band)
+                                               l_toeplitz, l_exact, dl_band,
+                                               int(spin0_only))
 
     def write_to(self, fname):
         """

--- a/pymaster/namaster.i
+++ b/pymaster/namaster.i
@@ -742,17 +742,17 @@ void write_covar_workspace(nmt_covar_workspace *cw,char *fname)
   nmt_covar_workspace_write_fits(cw,fname);
 }
 
-nmt_covar_workspace *read_covar_workspace(char *fname)
+nmt_covar_workspace *read_covar_workspace(char *fname,int force_spin0)
 {
-  return nmt_covar_workspace_read_fits(fname);
+  return nmt_covar_workspace_read_fits(fname,force_spin0);
 }
 
 nmt_covar_workspace *covar_workspace_init_py(nmt_field *fa1,nmt_field *fa2,
 					     nmt_field *fb1,nmt_field *fb2,
 					     int lmax,int n_iter,int l_toeplitz,
-                                             int l_exact,int dl_band)
+                                             int l_exact,int dl_band,int spin0_only)
 {
-  return nmt_covar_workspace_init(fa1,fa2,fb1,fb2,lmax,n_iter,l_toeplitz,l_exact,dl_band);
+  return nmt_covar_workspace_init(fa1,fa2,fb1,fb2,lmax,n_iter,l_toeplitz,l_exact,dl_band,spin0_only);
 }
 
 void write_covar_workspace_flat(nmt_covar_workspace_flat *cw,char *fname)

--- a/pymaster/namaster_wrap.c
+++ b/pymaster/namaster_wrap.c
@@ -3688,17 +3688,17 @@ void write_covar_workspace(nmt_covar_workspace *cw,char *fname)
   nmt_covar_workspace_write_fits(cw,fname);
 }
 
-nmt_covar_workspace *read_covar_workspace(char *fname)
+nmt_covar_workspace *read_covar_workspace(char *fname,int force_spin0)
 {
-  return nmt_covar_workspace_read_fits(fname);
+  return nmt_covar_workspace_read_fits(fname,force_spin0);
 }
 
 nmt_covar_workspace *covar_workspace_init_py(nmt_field *fa1,nmt_field *fa2,
 					     nmt_field *fb1,nmt_field *fb2,
 					     int lmax,int n_iter,int l_toeplitz,
-                                             int l_exact,int dl_band)
+                                             int l_exact,int dl_band,int spin0_only)
 {
-  return nmt_covar_workspace_init(fa1,fa2,fb1,fb2,lmax,n_iter,l_toeplitz,l_exact,dl_band);
+  return nmt_covar_workspace_init(fa1,fa2,fb1,fb2,lmax,n_iter,l_toeplitz,l_exact,dl_band,spin0_only);
 }
 
 void write_covar_workspace_flat(nmt_covar_workspace_flat *cw,char *fname)
@@ -15213,6 +15213,58 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_covar_workspace_spin0_only_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  nmt_covar_workspace *arg1 = (nmt_covar_workspace *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject *swig_obj[2] ;
+  
+  if (!SWIG_Python_UnpackTuple(args, "covar_workspace_spin0_only_set", 2, 2, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_nmt_covar_workspace, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "covar_workspace_spin0_only_set" "', argument " "1"" of type '" "nmt_covar_workspace *""'"); 
+  }
+  arg1 = (nmt_covar_workspace *)(argp1);
+  ecode2 = SWIG_AsVal_int(swig_obj[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "covar_workspace_spin0_only_set" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = (int)(val2);
+  if (arg1) (arg1)->spin0_only = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_covar_workspace_spin0_only_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  nmt_covar_workspace *arg1 = (nmt_covar_workspace *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  int result;
+  
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_nmt_covar_workspace, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "covar_workspace_spin0_only_get" "', argument " "1"" of type '" "nmt_covar_workspace *""'"); 
+  }
+  arg1 = (nmt_covar_workspace *)(argp1);
+  result = (int) ((arg1)->spin0_only);
+  resultobj = SWIG_From_int((int)(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_covar_workspace_xi00_1122_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   nmt_covar_workspace *arg1 = (nmt_covar_workspace *) 0 ;
@@ -15722,6 +15774,7 @@ SWIGINTERN PyObject *_wrap_covar_workspace_init(PyObject *SWIGUNUSEDPARM(self), 
   int arg7 ;
   int arg8 ;
   int arg9 ;
+  int arg10 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 = 0 ;
@@ -15740,10 +15793,12 @@ SWIGINTERN PyObject *_wrap_covar_workspace_init(PyObject *SWIGUNUSEDPARM(self), 
   int ecode8 = 0 ;
   int val9 ;
   int ecode9 = 0 ;
-  PyObject *swig_obj[9] ;
+  int val10 ;
+  int ecode10 = 0 ;
+  PyObject *swig_obj[10] ;
   nmt_covar_workspace *result = 0 ;
   
-  if (!SWIG_Python_UnpackTuple(args, "covar_workspace_init", 9, 9, swig_obj)) SWIG_fail;
+  if (!SWIG_Python_UnpackTuple(args, "covar_workspace_init", 10, 10, swig_obj)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_nmt_field, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "covar_workspace_init" "', argument " "1"" of type '" "nmt_field *""'"); 
@@ -15789,7 +15844,12 @@ SWIGINTERN PyObject *_wrap_covar_workspace_init(PyObject *SWIGUNUSEDPARM(self), 
     SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "covar_workspace_init" "', argument " "9"" of type '" "int""'");
   } 
   arg9 = (int)(val9);
-  result = (nmt_covar_workspace *)nmt_covar_workspace_init(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9);
+  ecode10 = SWIG_AsVal_int(swig_obj[9], &val10);
+  if (!SWIG_IsOK(ecode10)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode10), "in method '" "covar_workspace_init" "', argument " "10"" of type '" "int""'");
+  } 
+  arg10 = (int)(val10);
+  result = (nmt_covar_workspace *)nmt_covar_workspace_init(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_nmt_covar_workspace, 0 |  0 );
   return resultobj;
 fail:
@@ -16166,20 +16226,27 @@ fail:
 SWIGINTERN PyObject *_wrap_covar_workspace_read_fits(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   char *arg1 = (char *) 0 ;
+  int arg2 ;
   int res1 ;
   char *buf1 = 0 ;
   int alloc1 = 0 ;
-  PyObject *swig_obj[1] ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject *swig_obj[2] ;
   nmt_covar_workspace *result = 0 ;
   
-  if (!args) SWIG_fail;
-  swig_obj[0] = args;
+  if (!SWIG_Python_UnpackTuple(args, "covar_workspace_read_fits", 2, 2, swig_obj)) SWIG_fail;
   res1 = SWIG_AsCharPtrAndSize(swig_obj[0], &buf1, NULL, &alloc1);
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "covar_workspace_read_fits" "', argument " "1"" of type '" "char *""'");
   }
   arg1 = (char *)(buf1);
-  result = (nmt_covar_workspace *)nmt_covar_workspace_read_fits(arg1);
+  ecode2 = SWIG_AsVal_int(swig_obj[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "covar_workspace_read_fits" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = (int)(val2);
+  result = (nmt_covar_workspace *)nmt_covar_workspace_read_fits(arg1,arg2);
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_nmt_covar_workspace, 0 |  0 );
   if (alloc1 == SWIG_NEWOBJ) free((char*)buf1);
   return resultobj;
@@ -20339,22 +20406,29 @@ fail:
 SWIGINTERN PyObject *_wrap_read_covar_workspace(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   char *arg1 = (char *) 0 ;
+  int arg2 ;
   int res1 ;
   char *buf1 = 0 ;
   int alloc1 = 0 ;
-  PyObject *swig_obj[1] ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject *swig_obj[2] ;
   nmt_covar_workspace *result = 0 ;
   
-  if (!args) SWIG_fail;
-  swig_obj[0] = args;
+  if (!SWIG_Python_UnpackTuple(args, "read_covar_workspace", 2, 2, swig_obj)) SWIG_fail;
   res1 = SWIG_AsCharPtrAndSize(swig_obj[0], &buf1, NULL, &alloc1);
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_covar_workspace" "', argument " "1"" of type '" "char *""'");
   }
   arg1 = (char *)(buf1);
+  ecode2 = SWIG_AsVal_int(swig_obj[1], &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "read_covar_workspace" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = (int)(val2);
   {
     try {
-      result = (nmt_covar_workspace *)read_covar_workspace(arg1);
+      result = (nmt_covar_workspace *)read_covar_workspace(arg1,arg2);
     }
     finally {
       SWIG_exception(SWIG_RuntimeError,nmt_error_message);
@@ -20380,6 +20454,7 @@ SWIGINTERN PyObject *_wrap_covar_workspace_init_py(PyObject *SWIGUNUSEDPARM(self
   int arg7 ;
   int arg8 ;
   int arg9 ;
+  int arg10 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 = 0 ;
@@ -20398,10 +20473,12 @@ SWIGINTERN PyObject *_wrap_covar_workspace_init_py(PyObject *SWIGUNUSEDPARM(self
   int ecode8 = 0 ;
   int val9 ;
   int ecode9 = 0 ;
-  PyObject *swig_obj[9] ;
+  int val10 ;
+  int ecode10 = 0 ;
+  PyObject *swig_obj[10] ;
   nmt_covar_workspace *result = 0 ;
   
-  if (!SWIG_Python_UnpackTuple(args, "covar_workspace_init_py", 9, 9, swig_obj)) SWIG_fail;
+  if (!SWIG_Python_UnpackTuple(args, "covar_workspace_init_py", 10, 10, swig_obj)) SWIG_fail;
   res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_nmt_field, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "covar_workspace_init_py" "', argument " "1"" of type '" "nmt_field *""'"); 
@@ -20447,9 +20524,14 @@ SWIGINTERN PyObject *_wrap_covar_workspace_init_py(PyObject *SWIGUNUSEDPARM(self
     SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "covar_workspace_init_py" "', argument " "9"" of type '" "int""'");
   } 
   arg9 = (int)(val9);
+  ecode10 = SWIG_AsVal_int(swig_obj[9], &val10);
+  if (!SWIG_IsOK(ecode10)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode10), "in method '" "covar_workspace_init_py" "', argument " "10"" of type '" "int""'");
+  } 
+  arg10 = (int)(val10);
   {
     try {
-      result = (nmt_covar_workspace *)covar_workspace_init_py(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9);
+      result = (nmt_covar_workspace *)covar_workspace_init_py(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10);
     }
     finally {
       SWIG_exception(SWIG_RuntimeError,nmt_error_message);
@@ -22760,6 +22842,8 @@ static PyMethodDef SwigMethods[] = {
 	 { "compute_gaussian_covariance_flat", _wrap_compute_gaussian_covariance_flat, METH_VARARGS, NULL},
 	 { "covar_workspace_lmax_set", _wrap_covar_workspace_lmax_set, METH_VARARGS, NULL},
 	 { "covar_workspace_lmax_get", _wrap_covar_workspace_lmax_get, METH_O, NULL},
+	 { "covar_workspace_spin0_only_set", _wrap_covar_workspace_spin0_only_set, METH_VARARGS, NULL},
+	 { "covar_workspace_spin0_only_get", _wrap_covar_workspace_spin0_only_get, METH_O, NULL},
 	 { "covar_workspace_xi00_1122_set", _wrap_covar_workspace_xi00_1122_set, METH_VARARGS, NULL},
 	 { "covar_workspace_xi00_1122_get", _wrap_covar_workspace_xi00_1122_get, METH_O, NULL},
 	 { "covar_workspace_xi00_1221_set", _wrap_covar_workspace_xi00_1221_set, METH_VARARGS, NULL},
@@ -22789,7 +22873,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "workspace_flat_read_fits", _wrap_workspace_flat_read_fits, METH_O, NULL},
 	 { "workspace_flat_write_fits", _wrap_workspace_flat_write_fits, METH_VARARGS, NULL},
 	 { "covar_workspace_write_fits", _wrap_covar_workspace_write_fits, METH_VARARGS, NULL},
-	 { "covar_workspace_read_fits", _wrap_covar_workspace_read_fits, METH_O, NULL},
+	 { "covar_workspace_read_fits", _wrap_covar_workspace_read_fits, METH_VARARGS, NULL},
 	 { "covar_workspace_flat_write_fits", _wrap_covar_workspace_flat_write_fits, METH_VARARGS, NULL},
 	 { "covar_workspace_flat_read_fits", _wrap_covar_workspace_flat_read_fits, METH_O, NULL},
 	 { "get_nell_list", _wrap_get_nell_list, METH_VARARGS, NULL},
@@ -22836,7 +22920,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "comp_deproj_bias", _wrap_comp_deproj_bias, METH_VARARGS, NULL},
 	 { "comp_deproj_bias_flat", _wrap_comp_deproj_bias_flat, METH_VARARGS, NULL},
 	 { "write_covar_workspace", _wrap_write_covar_workspace, METH_VARARGS, NULL},
-	 { "read_covar_workspace", _wrap_read_covar_workspace, METH_O, NULL},
+	 { "read_covar_workspace", _wrap_read_covar_workspace, METH_VARARGS, NULL},
 	 { "covar_workspace_init_py", _wrap_covar_workspace_init_py, METH_VARARGS, NULL},
 	 { "write_covar_workspace_flat", _wrap_write_covar_workspace_flat, METH_VARARGS, NULL},
 	 { "read_covar_workspace_flat", _wrap_read_covar_workspace_flat, METH_O, NULL},

--- a/pymaster/nmtlib.py
+++ b/pymaster/nmtlib.py
@@ -491,6 +491,7 @@ class covar_workspace(object):
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
     lmax = property(_nmtlib.covar_workspace_lmax_get, _nmtlib.covar_workspace_lmax_set)
+    spin0_only = property(_nmtlib.covar_workspace_spin0_only_get, _nmtlib.covar_workspace_spin0_only_set)
     xi00_1122 = property(_nmtlib.covar_workspace_xi00_1122_get, _nmtlib.covar_workspace_xi00_1122_set)
     xi00_1221 = property(_nmtlib.covar_workspace_xi00_1221_get, _nmtlib.covar_workspace_xi00_1221_set)
     xi02_1122 = property(_nmtlib.covar_workspace_xi02_1122_get, _nmtlib.covar_workspace_xi02_1122_set)
@@ -511,8 +512,8 @@ _nmtlib.covar_workspace_swigregister(covar_workspace)
 def covar_workspace_free(cw):
     return _nmtlib.covar_workspace_free(cw)
 
-def covar_workspace_init(fla1, fla2, flb1, flb2, lmax, niter, l_toeplitz, l_exact, dl_band):
-    return _nmtlib.covar_workspace_init(fla1, fla2, flb1, flb2, lmax, niter, l_toeplitz, l_exact, dl_band)
+def covar_workspace_init(fla1, fla2, flb1, flb2, lmax, niter, l_toeplitz, l_exact, dl_band, spin0_only):
+    return _nmtlib.covar_workspace_init(fla1, fla2, flb1, flb2, lmax, niter, l_toeplitz, l_exact, dl_band, spin0_only)
 
 def compute_gaussian_covariance(cw, spin_a, spin_b, spin_c, spin_d, wa, wb, clac, clad, clbc, clbd, covar_out):
     return _nmtlib.compute_gaussian_covariance(cw, spin_a, spin_b, spin_c, spin_d, wa, wb, clac, clad, clbc, clbd, covar_out)
@@ -535,8 +536,8 @@ def workspace_flat_write_fits(w, fname):
 def covar_workspace_write_fits(cw, fname):
     return _nmtlib.covar_workspace_write_fits(cw, fname)
 
-def covar_workspace_read_fits(fname):
-    return _nmtlib.covar_workspace_read_fits(fname)
+def covar_workspace_read_fits(fname, force_spin0):
+    return _nmtlib.covar_workspace_read_fits(fname, force_spin0)
 
 def covar_workspace_flat_write_fits(cw, fname):
     return _nmtlib.covar_workspace_flat_write_fits(cw, fname)
@@ -676,11 +677,11 @@ def comp_deproj_bias_flat(fl1, fl2, bin, lmn_x, lmx_x, lmn_y, lmx_y, nell3, ncl1
 def write_covar_workspace(cw, fname):
     return _nmtlib.write_covar_workspace(cw, fname)
 
-def read_covar_workspace(fname):
-    return _nmtlib.read_covar_workspace(fname)
+def read_covar_workspace(fname, force_spin0):
+    return _nmtlib.read_covar_workspace(fname, force_spin0)
 
-def covar_workspace_init_py(fa1, fa2, fb1, fb2, lmax, n_iter, l_toeplitz, l_exact, dl_band):
-    return _nmtlib.covar_workspace_init_py(fa1, fa2, fb1, fb2, lmax, n_iter, l_toeplitz, l_exact, dl_band)
+def covar_workspace_init_py(fa1, fa2, fb1, fb2, lmax, n_iter, l_toeplitz, l_exact, dl_band, spin0_only):
+    return _nmtlib.covar_workspace_init_py(fa1, fa2, fb1, fb2, lmax, n_iter, l_toeplitz, l_exact, dl_band, spin0_only)
 
 def write_covar_workspace_flat(cw, fname):
     return _nmtlib.write_covar_workspace_flat(cw, fname)

--- a/src/namaster.h
+++ b/src/namaster.h
@@ -1236,6 +1236,7 @@ void nmt_compute_gaussian_covariance_flat(nmt_covar_workspace_flat *cw,
  */
 typedef struct {
   int lmax; //!< Maximum multipole for the first set of power spectra
+  int spin0_only; //!< Whether this only stores the spin-0 MCMs
   flouble **xi00_1122; //!< First (a1b1-a2b2), 00, mode coupling matrix (see scientific documentation)
   flouble **xi00_1221; //!< Second (a1b2-a2b1), 00, mode coupling matrix (see scientific documentation)
   flouble **xi02_1122; //!< First (a1b1-a2b2), 02, mode coupling matrix (see scientific documentation)
@@ -1266,7 +1267,8 @@ void nmt_covar_workspace_free(nmt_covar_workspace *cw);
 nmt_covar_workspace *nmt_covar_workspace_init(nmt_field *fla1,nmt_field *fla2,
 					      nmt_field *flb1,nmt_field *flb2,
 					      int lmax,int niter,
-                                              int l_toeplitz,int l_exact,int dl_band);
+                                              int l_toeplitz,int l_exact,int dl_band,
+					      int spin0_only);
 
 /**
  * @brief Compute full-sky Gaussian covariance matrix
@@ -1390,8 +1392,9 @@ void nmt_covar_workspace_write_fits(nmt_covar_workspace *cw,char *fname);
  * future covariance matrix computations. The same workspace can be used on any pair of power spectra
  * between fields with the same masks.
  * @param fname Path to input file.
+ * @param force_spin0 Read and store only the spin-0 combinations
  */
-nmt_covar_workspace *nmt_covar_workspace_read_fits(char *fname);
+nmt_covar_workspace *nmt_covar_workspace_read_fits(char *fname,int force_spin0);
 
 /**
  * @brief Saves nmt_covar_workspace_flat structure to file

--- a/src/nmt_covar.c
+++ b/src/nmt_covar.c
@@ -53,12 +53,12 @@ nmt_covar_workspace *nmt_covar_workspace_init(nmt_field *fla1,nmt_field *fla2,
   cw->xi00_1122=c->xi_00[0];
   cw->xi00_1221=c->xi_00[1];
   if(cw->spin0_only) {
-    cw->xi02_1122=NULL;
-    cw->xi02_1221=NULL;
-    cw->xi22p_1122=NULL;
-    cw->xi22p_1221=NULL;
-    cw->xi22m_1122=NULL;
-    cw->xi22m_1221=NULL;
+    cw->xi02_1122=c->xi_00[0];
+    cw->xi02_1221=c->xi_00[1];
+    cw->xi22p_1122=c->xi_00[0];
+    cw->xi22p_1221=c->xi_00[1];
+    cw->xi22m_1122=c->xi_00[0];
+    cw->xi22m_1221=c->xi_00[1];
   }
   else {
     cw->xi02_1122=c->xi_0s[0][0];

--- a/src/nmt_io.c
+++ b/src/nmt_io.c
@@ -830,12 +830,12 @@ nmt_covar_workspace *nmt_covar_workspace_read_fits(char *fname, int force_spin0)
   cw->xi00_1221=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI00_1221",&status);
   check_fits(status,fname,1);
   if(cw->spin0_only) {
-    cw->xi02_1122=NULL;
-    cw->xi02_1221=NULL;
-    cw->xi22p_1122=NULL;
-    cw->xi22p_1221=NULL;
-    cw->xi22m_1122=NULL;
-    cw->xi22m_1221=NULL;
+    cw->xi02_1122=cw->xi00_1122;
+    cw->xi02_1221=cw->xi00_1221;
+    cw->xi22p_1122=cw->xi00_1122;
+    cw->xi22p_1221=cw->xi00_1221;
+    cw->xi22m_1122=cw->xi00_1122;
+    cw->xi22m_1221=cw->xi00_1221;
   }
   else {
     cw->xi02_1122=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI02_1122",&status);

--- a/src/nmt_io.c
+++ b/src/nmt_io.c
@@ -779,28 +779,31 @@ void nmt_covar_workspace_write_fits(nmt_covar_workspace *cw,char *fname)
   fits_create_img(fptr,BYTE_IMG,0,NULL,&status);
   fits_write_key(fptr,TSTRING,"EXTNAME","CWSP_PRIMARY",NULL,&status);
   fits_write_key(fptr,TINT,"LMAX",&(cw->lmax),NULL,&status);
+  fits_write_key(fptr,TINT,"SPIN0_ONLY",&(cw->spin0_only),NULL,&status);
   check_fits(status,fname,0);
 
   nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi00_1122,"XI00_1122",&status);
   check_fits(status,fname,0);
   nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi00_1221,"XI00_1221",&status);
   check_fits(status,fname,0);
-  nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi02_1122,"XI02_1122",&status);
-  check_fits(status,fname,0);
-  nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi02_1221,"XI02_1221",&status);
-  check_fits(status,fname,0);
-  nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi22p_1122,"XI22P_1122",&status);
-  check_fits(status,fname,0);
-  nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi22p_1221,"XI22P_1221",&status);
-  check_fits(status,fname,0);
-  nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi22m_1122,"XI22M_1122",&status);
-  check_fits(status,fname,0);
-  nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi22m_1221,"XI22M_1221",&status);
-  check_fits(status,fname,0);
+  if(cw->spin0_only == 0) {
+    nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi02_1122,"XI02_1122",&status);
+    check_fits(status,fname,0);
+    nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi02_1221,"XI02_1221",&status);
+    check_fits(status,fname,0);
+    nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi22p_1122,"XI22P_1122",&status);
+    check_fits(status,fname,0);
+    nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi22p_1221,"XI22P_1221",&status);
+    check_fits(status,fname,0);
+    nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi22m_1122,"XI22M_1122",&status);
+    check_fits(status,fname,0);
+    nmt_covar_coeffs_tohdus(fptr,cw->lmax+1,cw->xi22m_1221,"XI22M_1221",&status);
+    check_fits(status,fname,0);
+  }
   fits_close_file(fptr,&status);
 }
 
-nmt_covar_workspace *nmt_covar_workspace_read_fits(char *fname)
+nmt_covar_workspace *nmt_covar_workspace_read_fits(char *fname, int force_spin0)
 {
   fitsfile *fptr;
   int status=0;
@@ -811,24 +814,43 @@ nmt_covar_workspace *nmt_covar_workspace_read_fits(char *fname)
   fits_movnam_hdu(fptr,ANY_HDU,"CWSP_PRIMARY",0,&status);
   fits_read_key(fptr,TINT,"LMAX",&(cw->lmax),NULL,&status);
   check_fits(status,fname,1);
+  if(force_spin0)
+    cw->spin0_only=1;
+  else {
+    fits_read_key(fptr,TINT,"SPIN0_ONLY",&(cw->spin0_only),NULL,&status);
+    if(status) {//Old format, always includes all spins
+      cw->spin0_only=0;
+      status=0;
+    }
+  }
   //Empty primary
 
   cw->xi00_1122=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI00_1122",&status);
   check_fits(status,fname,1);
   cw->xi00_1221=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI00_1221",&status);
   check_fits(status,fname,1);
-  cw->xi02_1122=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI02_1122",&status);
-  check_fits(status,fname,1);
-  cw->xi02_1221=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI02_1221",&status);
-  check_fits(status,fname,1);
-  cw->xi22p_1122=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI22P_1122",&status);
-  check_fits(status,fname,1);
-  cw->xi22p_1221=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI22P_1221",&status);
-  check_fits(status,fname,1);
-  cw->xi22m_1122=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI22M_1122",&status);
-  check_fits(status,fname,1);
-  cw->xi22m_1221=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI22M_1221",&status);
-  check_fits(status,fname,1);
+  if(cw->spin0_only) {
+    cw->xi02_1122=NULL;
+    cw->xi02_1221=NULL;
+    cw->xi22p_1122=NULL;
+    cw->xi22p_1221=NULL;
+    cw->xi22m_1122=NULL;
+    cw->xi22m_1221=NULL;
+  }
+  else {
+    cw->xi02_1122=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI02_1122",&status);
+    check_fits(status,fname,1);
+    cw->xi02_1221=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI02_1221",&status);
+    check_fits(status,fname,1);
+    cw->xi22p_1122=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI22P_1122",&status);
+    check_fits(status,fname,1);
+    cw->xi22p_1221=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI22P_1221",&status);
+    check_fits(status,fname,1);
+    cw->xi22m_1122=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI22M_1122",&status);
+    check_fits(status,fname,1);
+    cw->xi22m_1221=nmt_covar_coeffs_fromhdus(fptr,cw->lmax+1,"XI22M_1221",&status);
+    check_fits(status,fname,1);
+  }
   fits_close_file(fptr,&status);
 
   return cw;

--- a/test/nmt_test_covar.c
+++ b/test/nmt_test_covar.c
@@ -10,7 +10,7 @@ CTEST(nmt,covar_f_ell) {
   double *map=he_read_map("test/benchmarks/mps.fits",cs,0);
   nmt_workspace *w=nmt_workspace_read_fits("test/benchmarks/bm_nc_np_w00.fits");
   nmt_field *f0=nmt_field_alloc_sph(cs,msk,0,&map,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT,0,0,0);
-  nmt_covar_workspace *cw=nmt_covar_workspace_init(f0,f0,f0,f0,w->bin->ell_max,HE_NITER_DEFAULT,-1,-1,-1);
+  nmt_covar_workspace *cw=nmt_covar_workspace_init(f0,f0,f0,f0,w->bin->ell_max,HE_NITER_DEFAULT,-1,-1,-1,0);
   nmt_field_free(f0);
   free(msk); free(map);
   nmt_bins_free(w->bin);
@@ -57,8 +57,8 @@ CTEST(nmt,covar) {
   double *map=he_read_map("test/benchmarks/mps.fits",cs,0);
   nmt_workspace *w=nmt_workspace_read_fits("test/benchmarks/bm_nc_np_w00.fits");
   nmt_field *f0=nmt_field_alloc_sph(cs,msk,0,&map,0,NULL,NULL,0,0,3,1E-10,HE_NITER_DEFAULT,0,0,0);
-  nmt_covar_workspace *cw=nmt_covar_workspace_init(f0,f0,f0,f0,w->bin->ell_max,HE_NITER_DEFAULT,-1,-1,-1);
-  nmt_covar_workspace *cwr=nmt_covar_workspace_read_fits("test/benchmarks/bm_nc_np_cw00.fits");
+  nmt_covar_workspace *cw=nmt_covar_workspace_init(f0,f0,f0,f0,w->bin->ell_max,HE_NITER_DEFAULT,-1,-1,-1,0);
+  nmt_covar_workspace *cwr=nmt_covar_workspace_read_fits("test/benchmarks/bm_nc_np_cw00.fits", 0);
   nmt_field_free(f0);
   free(msk); free(map);
 
@@ -121,22 +121,22 @@ CTEST(nmt,covar_errors) {
   set_error_policy(THROW_ON_ERROR);
 
   //All good
-  try { cw=nmt_covar_workspace_init(f0,f0,f0b,f0b,binb->ell_max,HE_NITER_DEFAULT,-1,-1,-1); }
+  try { cw=nmt_covar_workspace_init(f0,f0,f0b,f0b,binb->ell_max,HE_NITER_DEFAULT,-1,-1,-1,0); }
   ASSERT_EQUAL(0,nmt_exception_status);
   nmt_covar_workspace_free(cw); cw=NULL;
   //Wrong reading
-  try { cw=nmt_covar_workspace_read_fits("none"); }
+  try { cw=nmt_covar_workspace_read_fits("none", 0); }
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(cw);
 
   //Correct reading
-  try { cw=nmt_covar_workspace_read_fits("test/benchmarks/bm_nc_np_cw00.fits"); }
+  try { cw=nmt_covar_workspace_read_fits("test/benchmarks/bm_nc_np_cw00.fits", 0); }
   ASSERT_EQUAL(0,nmt_exception_status);
   nmt_covar_workspace_free(cw); cw=NULL;
 
   //Incompatible resolutions
   f0b->cs->n_eq=128;
-  try { cw=nmt_covar_workspace_init(f0,f0,f0b,f0b,binb->ell_max,HE_NITER_DEFAULT,-1,-1,-1); }
+  try { cw=nmt_covar_workspace_init(f0,f0,f0b,f0b,binb->ell_max,HE_NITER_DEFAULT,-1,-1,-1,0); }
   f0b->cs->n_eq=nside;
   ASSERT_NOT_EQUAL(0,nmt_exception_status);
   ASSERT_NULL(cw);


### PR DESCRIPTION
The most common usage of the existing Gaussian covariance implementation is for spin-0 fields. Additionally, treating spin-2 fields as pairs of spin-0 fields often leads to a better approximation for complicated masks (see e.g. https://arxiv.org/abs/2010.09717).
In turn, the covariance workspaces in NaMaster always compute and store all spin-0 and spin-2 combinations which is both slow and memory-consuming.

This modification allows users to avoid computing any non-spin-0 covariance MCMs and to avoid reading them from file if desired.