### PR TITLE
Add LDADD flag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,7 @@ include_HEADERS = src/namaster.h
 
 bin_PROGRAMS = namaster
 namaster_SOURCES = src/nmt_main.c
+namaster_LDADD = libnmt.la
 namaster_CPPFLAGS = $(OPENMP_CFLAGS) -I./src/
 namaster_LDFLAGS = $(OPENMP_CFLAGS) -L./ -lnmt @fftw_thread_type@ -lfftw3 -lgsl -lgslcblas -lcfitsio @libsharp_libs@ -lm
 


### PR DESCRIPTION
This makes sure the library is built first and then the `namaster` bin program. 

This should (partially) fixed #156 but one needs to rebuild all configuration files with `autoreconf -ivf` (and thus update all the config*, depcomp... files available in this repository). This is needed by libtool 2.4.7 (as explained in #156 but this is also true for recent linux boxes) but I don't know how backward compatible it is.

Reference https://www.gnu.org/software/automake/manual/automake.html#Libtool-Libraries

Tested on linux OS and Mac OS.