### PR TITLE
Faster Wigner

### DIFF
--- a/src/namaster.h
+++ b/src/namaster.h
@@ -959,6 +959,7 @@ typedef struct {
   int has_ss;
   flouble ****xi_pp;
   flouble ****xi_mm;
+  double *lfac;
   int pure_e1;
   int pure_e2;
   int pure_b1;

--- a/src/nmt_master.c
+++ b/src/nmt_master.c
@@ -1311,7 +1311,8 @@ nmt_workspace *nmt_compute_power_spectra(nmt_field *fl1,nmt_field *fl2,
     cl_data[ii]=my_calloc((fl1->lmax+1),sizeof(flouble));
   }
   nmt_compute_coupled_cell(fl1,fl2,cl_data);
-  nmt_compute_deprojection_bias(fl1,fl2,cl_proposal,cl_bias,niter);
+  if(!(fl1->lite || fl2->lite))
+    nmt_compute_deprojection_bias(fl1,fl2,cl_proposal,cl_bias,niter);
   nmt_decouple_cl_l(w,cl_data,cl_noise,cl_bias,cl_out);
   for(ii=0;ii<w->ncls;ii++) {
     free(cl_bias[ii]);

--- a/src/nmt_master.c
+++ b/src/nmt_master.c
@@ -261,7 +261,7 @@ static void populate_toeplitz(nmt_master_calculator *c, flouble **pcl_masks, int
         lmax_here=ll2+ll3;
 
 	if(c->has_00 || c->has_0s)
-	  drc3jj(ll2,ll3,0,0,&lmin_00,&lmax_00,wigner_00,2*(c->lmax_mask+1));
+	  drc3jj_000(ll2,ll3,&lmin_00,&lmax_00,c->lfac,wigner_00,2*(c->lmax_mask+1));
 	if(c->has_0s || c->has_ss)
 	  drc3jj(ll2,ll3,c->s1,-c->s1,&lmin_ss1,&lmax_ss1,wigner_ss1,2*(c->lmax_mask+1));
         if(has_ss2)
@@ -521,6 +521,14 @@ nmt_master_calculator *nmt_compute_master_coefficients(int lmax, int lmax_mask,
     }
   }
 
+  int lmax_max = NMT_MAX(c->lmax, c->lmax_mask);
+  c->lfac = my_malloc(3*(lmax_max+1)*sizeof(double));
+  // Precompute log-factorial
+  c->lfac[0] = 0.0;
+  c->lfac[1] = 0.0;
+  for(ii=2;ii<3*(lmax_max+1);ii++)
+    c->lfac[ii] = c->lfac[ii-1]+log((double)(ii));
+
   if(l_toeplitz>0)
     populate_toeplitz(c, pcl_masks, l_toeplitz);
 
@@ -581,7 +589,7 @@ nmt_master_calculator *nmt_compute_master_coefficients(int lmax, int lmax_mask,
         }
 
         if(c->has_00 || c->has_0s)
-          drc3jj(ll2,ll3,0,0,&lmin_00,&lmax_00,wigner_00,2*(c->lmax_mask+1));
+	  drc3jj_000(ll2,ll3,&lmin_00,&lmax_00,c->lfac,wigner_00,2*(c->lmax_mask+1));
         if(c->has_0s || c->has_ss)
           drc3jj(ll2,ll3,c->s1,-c->s1,&lmin_ss1,&lmax_ss1,wigner_ss1,2*(c->lmax_mask+1));
         if(has_ss2)
@@ -803,6 +811,7 @@ void nmt_master_calculator_free(nmt_master_calculator *c)
     free(c->xi_pp);
     free(c->xi_mm);
   }
+  free(c->lfac);
   free(c);
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -182,6 +182,29 @@ int drc3jj(int il2,int il3,int im2, int im3,int *l1min_out,
 	   int *l1max_out,double *thrcof,int size);
 
 /**
+ * @brief Wigner 3-j symbols
+ *
+ * Returns all non-zero wigner-3j symbols with m=0
+ * \f[
+ *    \left(
+ *    \begin{array}{ccc}
+ *      \ell_1 & \ell_2 & \ell_3 \\
+ *      0      & 0      & 0
+ *     \end{array}
+ *     \right),
+ * \f]
+ * for
+ * @param il2 =\f$\ell_2\f$
+ * @param il3 =\f$\ell_3\f$
+ * @param l1min_out Minimum value of \f$\ell_1\f$ allowed by selection rules (output).
+ * @param l1max_out Maximum value of \f$\ell_1\f$ allowed by selection rules (output).
+ * @param thrcof Output array that will contain the values of the wigner-3j symbols for \p l1min_out \f$\leq\ell_1\leq\f$ \p l1max_out.
+ * @param size Number of elements allocated for thrcof.
+ */
+int drc3jj_000(int il2,int il3,int *l1min_out,int *l1max_out,
+	       double *lfac,double *thrcof,int size);
+
+/**
  * @brief Moore-Penrose pseudo-inverse.
  *
  * Returns the <a href="https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse">Moore-Penrose pseudo-inverse</a>.


### PR DESCRIPTION
Implementing a simpler expression for the Wigner 3-J symbols for m_i=0 (useful for scalar fields) leads to a ~20-30% speedup in the calculation of coupling matrices.