### PR TITLE
Nitpicky fix for Wigner 3j sign convention

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -368,8 +368,7 @@ int drc3jj(int il2,int il3,int im2, int im3,int *l1min_out,
 	sumuni=sum1;
       
       cnorm=1./sqrt(sumuni);
-      if(thrcof[nfin-1]<0) sign1=-1;
-      else sign1=1;
+      sign1 = copysign(1., thrcof[nfin-1]);
       
       if(sign1*sign2<=0)
 	cnorm=-cnorm;


### PR DESCRIPTION
While playing with various implementations of the Wigner 3j recurrence, I noticed a small problem with the version used in Namaster: whenever the last coefficient is so small that it underflows to zero, the sign of the returned coefficients may be wrong. As far as I can see, this makes no difference in practice for NaMaster, since only the squares of the coefficients are used, so this is mostly relevant for people wanting to use Namaster's Wigner 3j implementation for other purposes.
Note that the original Fortran implementation also explicitly checks for the sign of the coefficient (see, e.g., https://github.com/fujiisoup/py3nj/blob/bfcd5f466dd88f2d40785999e5a1ed5299a66cef/fortran/drc3jj.f#L412), making use of the fact that IEEE arithmetics distinguishes between +0 and -0.