### PR TITLE
Fix API-breaking change in ducc0

### DIFF
--- a/pymaster/utils.py
+++ b/pymaster/utils.py
@@ -852,7 +852,8 @@ _a2m_d = {'ducc': _alm2map_ducc0,
 def _catalog2alm_ducc0(values, positions, spin, lmax):
     values = np.atleast_2d(values)
     alm = ducc0.sht.adjoint_synthesis_general(lmax=lmax, map=values,
-                                              loc=positions.T, spin=int(spin))
+                                              loc=positions.T, spin=int(spin),
+                                              epsilon=1E-5)
     return alm
 
 


### PR DESCRIPTION
A recent [update](https://gitlab.mpcdf.mpg.de/mtr/ducc/-/commit/e989e361c5f23ebdc8dc44aadd533493c814419a) to `ducc0` breaks the API. This PR adapts the way we call ducc0 to fix this. Thanks @anicola for noticing this and providing the fix.