### PR TITLE
Mode deprojection for NmtFieldCatalogClustering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install fitsio, fftw (ubuntu)
         if: matrix.label == 'linux-64'
         run: |
-          sudo -H apt-get install libcfitsio-dev libfftw3-dev
+          sudo -H apt-get install libcfitsio-dev libfftw3-dev libgsl-dev
 
       - name: Install other dependencies (mac)
         if: matrix.label == 'osx-64'

--- a/pymaster/field.py
+++ b/pymaster/field.py
@@ -1004,9 +1004,9 @@ class NmtFieldCatalogClustering(NmtField):
             field's mask. Should be 1-dimensional for a HEALPix map or
             2-dimensional for a map with rectangular (CAR) pixelization.
             If not ``None``, the random catalogue (``positions_rand`` and
-            ``weights_rand``). Note that, if deprojection templates are
-            provided but no mask is passed, a mask will be constructed
-            from the random catalogue for deprojection.
+            ``weights_rand``) will be ignored. Note that, if deprojection
+            templates are provided but no mask is passed, a mask will be
+            constructed from the random catalogue for deprojection.
         lonlat (:obj:`bool`): If ``True``, longitude and latitude in degrees
             are provided as input. If ``False``, colatitude and longitude in
             radians are provided instead.

--- a/pymaster/field.py
+++ b/pymaster/field.py
@@ -1182,7 +1182,6 @@ class NmtFieldCatalogClustering(NmtField):
                 n_iter = ut.nmt_params.n_iter_default
             if tol_pinv is None:
                 tol_pinv = ut.nmt_params.tol_pinv_default
-            self.n_temp = len(templates)
 
             # Check format of templates
             if isinstance(templates, (list, tuple, np.ndarray)):
@@ -1193,6 +1192,7 @@ class NmtFieldCatalogClustering(NmtField):
             else:
                 raise ValueError("Input templates can only be an array "
                                  "or None")
+            self.n_temp = len(templates)
 
             # Method of deprojection depends on whether mask provided
             if mask is None:

--- a/pymaster/field.py
+++ b/pymaster/field.py
@@ -977,6 +977,15 @@ class NmtFieldCatalogClustering(NmtField):
     of discrete sources, with a survey footprint characterised by a set of
     random points or through a standard mask.
 
+    .. note::
+        The ordering of arguments for this class will change in the next
+        major version of NaMaster.
+
+    .. note::
+        Currently only HEALPix format is accepted for the mask and
+        templates passed to this field, but we hope to implement CAR
+        pixelisation in the near future.
+
     Args:
         positions (`array`): Source positions, provided as a list or array
             of 2 arrays. If ``lonlat`` is True, the arrays should contain the
@@ -987,17 +996,17 @@ class NmtFieldCatalogClustering(NmtField):
             coordinates :math:`(\\theta,\\phi)`).
         weights (`array`): An array containing the weight assigned to
             each source.
-        lmax (:obj:`int`): Maximum multipole up to which the spherical
-            harmonics of this field will be computed.
         positions_rand (`array`): As ``positions`` for the random catalog.
         weights_rand (`array`): As ``weights`` for the random catalog.
+        lmax (:obj:`int`): Maximum multipole up to which the spherical
+            harmonics of this field will be computed.
         mask (`array`): Array containing a map corresponding to the
             field's mask. Should be 1-dimensional for a HEALPix map or
             2-dimensional for a map with rectangular (CAR) pixelization.
-            Only used if ``templates`` is not ``None`` and
-            ``masked_on_input=False``. If not provided despite these conditions
-            being true, a mask will be constructed from the positions of the
-            randoms.
+            If not ``None``, the random catalogue (``positions_rand`` and
+            ``weights_rand``). Note that, if deprojection templates are
+            provided but no mask is passed, a mask will be constructed
+            from the random catalogue for deprojection.
         lonlat (:obj:`bool`): If ``True``, longitude and latitude in degrees
             are provided as input. If ``False``, colatitude and longitude in
             radians are provided instead.
@@ -1036,8 +1045,8 @@ class NmtFieldCatalogClustering(NmtField):
             :meth:`~pymaster.utils.get_default_params`, and modified via
             :meth:`~pymaster.utils.set_tol_pinv_default`.
     """
-    def __init__(self, positions, weights, lmax, positions_rand=None,
-                 weights_rand=None, mask=None, lonlat=False, templates=None,
+    def __init__(self, positions, weights, positions_rand, weights_rand,
+                 lmax, lonlat=False, mask=None, templates=None,
                  masked_on_input=False, n_iter=None, n_iter_mask=None,
                  wcs=None, tol_pinv=None):
         # Preliminary initializations

--- a/pymaster/field.py
+++ b/pymaster/field.py
@@ -987,10 +987,17 @@ class NmtFieldCatalogClustering(NmtField):
             coordinates :math:`(\\theta,\\phi)`).
         weights (`array`): An array containing the weight assigned to
             each source.
-        positions_rand (`array`): As ``positions`` for the random catalog.
-        weights_rand (`array`): As ``weights`` for the random catalog.
         lmax (:obj:`int`): Maximum multipole up to which the spherical
             harmonics of this field will be computed.
+        positions_rand (`array`): As ``positions`` for the random catalog.
+        weights_rand (`array`): As ``weights`` for the random catalog.
+        mask (`array`): Array containing a map corresponding to the
+            field's mask. Should be 1-dimensional for a HEALPix map or
+            2-dimensional for a map with rectangular (CAR) pixelization.
+            Only used if ``templates`` is not ``None`` and
+            ``masked_on_input=False``. If not provided despite these conditions
+            being true, a mask will be constructed from the positions of the
+            randoms.
         lonlat (:obj:`bool`): If ``True``, longitude and latitude in degrees
             are provided as input. If ``False``, colatitude and longitude in
             radians are provided instead.
@@ -1004,13 +1011,6 @@ class NmtFieldCatalogClustering(NmtField):
             ``templates=None``.
         masked_on_input (:obj:`bool`): Set to ``True`` if the input templates
             are already multiplied by the mask.
-        mask (`array`): Array containing a map corresponding to the
-            field's mask. Should be 1-dimensional for a HEALPix map or
-            2-dimensional for a map with rectangular (CAR) pixelization.
-            Only used if ``templates`` is not ``None`` and
-            ``masked_on_input=False``. If not provided despite these conditions
-            being true, a mask will be constructed from the positions of the
-            randoms.
         n_iter (:obj:`int`): Number of iterations when computing the
             :math:`a_{\\ell m}` s of the input maps. See the documentation of
             :meth:`~pymaster.utils.map2alm`. If ``None``, it will default to
@@ -1030,9 +1030,9 @@ class NmtFieldCatalogClustering(NmtField):
             :meth:`~pymaster.utils.get_default_params`, and modified via
             :meth:`~pymaster.utils.set_tol_pinv_default`.
     """
-    def __init__(self, positions, weights, positions_rand, weights_rand,
-                 lmax, lonlat=False, templates=None, masked_on_input=False,
-                 mask=None, n_iter=None, wcs=None, tol_pinv=None):
+    def __init__(self, positions, weights, lmax, positions_rand=None,
+                 weights_rand=None, mask=None, lonlat=False, templates=None,
+                 masked_on_input=False, n_iter=None, wcs=None, tol_pinv=None):
         # Preliminary initializations
         if ut.HAVE_DUCC:
             self.sht_calculator = 'ducc'

--- a/pymaster/field.py
+++ b/pymaster/field.py
@@ -1002,14 +1002,14 @@ class NmtFieldCatalogClustering(NmtField):
             rectangular pixels. The best-fit contribution from each
             contaminant is automatically removed from the maps unless
             ``templates=None``.
-        masked_on_input (:obj:`bool`): Set to ``True`` if the input templates 
+        masked_on_input (:obj:`bool`): Set to ``True`` if the input templates
             are already multiplied by the mask.
         mask (`array`): Array containing a map corresponding to the
             field's mask. Should be 1-dimensional for a HEALPix map or
             2-dimensional for a map with rectangular (CAR) pixelization.
-            Only used if ``templates`` is not ``None`` and 
+            Only used if ``templates`` is not ``None`` and
             ``masked_on_input=False``. If not provided despite these conditions
-            being true, a mask will be constructed from the positions of the 
+            being true, a mask will be constructed from the positions of the
             randoms.
         n_iter (:obj:`int`): Number of iterations when computing the
             :math:`a_{\\ell m}` s of the input maps. See the documentation of
@@ -1031,7 +1031,7 @@ class NmtFieldCatalogClustering(NmtField):
             :meth:`~pymaster.utils.set_tol_pinv_default`.
     """
     def __init__(self, positions, weights, positions_rand, weights_rand,
-                 lmax, lonlat=False, templates=None, masked_on_input=False, 
+                 lmax, lonlat=False, templates=None, masked_on_input=False,
                  mask=None, n_iter=None, wcs=None, tol_pinv=None):
         # Preliminary initializations
         if ut.HAVE_DUCC:
@@ -1056,7 +1056,7 @@ class NmtFieldCatalogClustering(NmtField):
         self.spin = 0
         self.is_catalog = True
 
-        # These attributes are only required if templates are provided for deprojection
+        # These attributes only required if templates provided for deprojection
         self.temp = None
         self.alm_temp = None
         # The remaining attributes are only required for non-lite maps
@@ -1137,7 +1137,7 @@ class NmtFieldCatalogClustering(NmtField):
             if tol_pinv is None:
                 tol_pinv = ut.nmt_params.tol_pinv_default
             self.n_temp = len(templates)
-            
+
             # Check format of templates
             if isinstance(templates, (list, tuple, np.ndarray)):
                 templates = np.array(templates, dtype=np.float64)
@@ -1151,7 +1151,7 @@ class NmtFieldCatalogClustering(NmtField):
             else:
                 raise ValueError("Input templates can only be an array "
                                  "or None")
-            
+
             # Get the number of pixels in each template and convert to NSIDE
             npix = len(templates[0][0])
             nside = hp.npix2nside(npix)
@@ -1164,7 +1164,8 @@ class NmtFieldCatalogClustering(NmtField):
                 # Check if a mask has been provided
                 if mask is None:
                     # Generate a mask from the positions of the randoms
-                    mask = np.bincount(ipix_rand, minlength=npix).astype(np.float64)
+                    mask = np.bincount(ipix_rand,
+                                       minlength=npix).astype(np.float64)
                     # Normalise to range [0,1]
                     mask /= mask.max()
                 # Get spatial info from mask
@@ -1172,7 +1173,7 @@ class NmtFieldCatalogClustering(NmtField):
 
                 # Multiply the templates by the mask
                 templates *= self.mask[None, :]
-            
+
             # Get the template values at each source's position
             temp_at_data = templates[:, :, ipix_data]
             temp_at_rand = templates[:, :, ipix_rand]
@@ -1183,13 +1184,13 @@ class NmtFieldCatalogClustering(NmtField):
             S_data = temp_at_data.sum(axis=2)
             S_rand = temp_at_rand.sum(axis=2)
             # Weighted difference between the two sums
-            dS = S_data - self._alpha * S_rand 
+            dS = S_data - self._alpha * S_rand
 
             # Compute alms of each template
             alm_temp = np.array([ut.map2alm(t, self.spin, self.minfo,
-                                                self.ainfo, n_iter=n_iter)
-                                     for t in templates])
-            
+                                            self.ainfo, n_iter=n_iter)
+                                for t in templates])
+
             # Compute template normalisation matrix
             M = np.array([[self.minfo.si.dot_map(t1, t2)
                            for t1 in templates]
@@ -1204,4 +1205,3 @@ class NmtFieldCatalogClustering(NmtField):
 
             # Subtract from the alms of the field
             self.alm -= alm_deproj
-

--- a/pymaster/tests/test_field_catalog.py
+++ b/pymaster/tests/test_field_catalog.py
@@ -310,3 +310,71 @@ def test_field_catalog_clustering_poisson():
         x = np.mean(c, axis=0)
         s = np.std(c, axis=0)/np.sqrt(nsims)
         assert np.all(np.fabs(x) < 5*s)
+
+
+def test_field_catalog_clustering_deproj():
+    nside = 128
+    npix = hp.nside2npix(nside)
+
+    # Create depth variations
+    depth = np.ones(npix)
+    for lat in np.linspace(-60, 60, 5):
+        for lon in np.linspace(0, 360, 10):
+            v = hp.ang2vec(lon, lat, lonlat=True)
+            ip = hp.query_disc(nside, v, np.radians(5))
+            depth[ip] = 0.7
+    fsky = np.sum(depth)/len(depth)
+    depth_var = depth - np.mean(depth)
+
+    # Create random catalog
+    pos_ran = np.array([np.arccos(-1+2*np.random.rand(4*npix)),
+                        2*np.pi*np.random.rand(4*npix)])
+    w_ran = np.ones(4*npix)
+
+    # Create dummy field for workspaces
+    b = nmt.NmtBin.from_nside_linear(nside, 4)
+    f = nmt.NmtFieldCatalogClustering(pos_ran, w_ran, pos_ran, w_ran,
+                                      lmax=3*nside-1)
+    w = nmt.NmtWorkspace.from_fields(f, f, b)
+
+    nsims = 10
+    ncat = npix//4
+    cls_biased = []
+    cls_deproj_cat = []
+    cls_deproj_msk = []
+    for i in range(nsims):
+        # Generate sim and get C_ell
+        pos_dat = np.array([np.arccos(-1+2*np.random.rand(ncat)),
+                            2*np.pi*np.random.rand(ncat)])
+        keep = np.random.rand(ncat) < depth[hp.ang2pix(nside, *pos_dat)]
+        pos_dat = pos_dat[:, keep]
+        w_dat = np.ones(pos_dat.shape[1])
+        f = nmt.NmtFieldCatalogClustering(pos_dat, w_dat, pos_ran, w_ran,
+                                          lmax=3*nside-1)
+        assert np.isclose(f.alpha, fsky/16, rtol=0.1)
+        cls_biased.append(w.decouple_cell(nmt.compute_coupled_cell(f, f)))
+        f = nmt.NmtFieldCatalogClustering(pos_dat, w_dat, pos_ran, w_ran,
+                                          lmax=3*nside-1,
+                                          templates=[[depth_var]])
+        cls_deproj_cat.append(w.decouple_cell(nmt.compute_coupled_cell(f, f)))
+        f = nmt.NmtFieldCatalogClustering(pos_dat, w_dat, None, None,
+                                          lmax=3*nside-1, mask=np.ones(npix),
+                                          templates=[[depth_var]])
+        cls_deproj_msk.append(w.decouple_cell(nmt.compute_coupled_cell(f, f)))
+    cls_biased = np.array(cls_biased).squeeze()
+    cls_deproj_cat = np.array(cls_deproj_cat).squeeze()
+    cls_deproj_msk = np.array(cls_deproj_msk).squeeze()
+
+    def check_biased(c_ells, biased_bad=True):
+        x = np.mean(c_ells, axis=0)
+        s = np.std(c_ells, axis=0)/np.sqrt(nsims)
+        if biased_bad:
+            assert np.all(np.fabs(x) < 5*s)
+        else:
+            assert np.any(np.fabs(x) > 5*s)
+
+    # Check that the power spectra are biased without deprojection
+    check_biased(cls_biased, biased_bad=False)
+    # But they're unbiased otherwise (whether randoms or mask are passed)
+    check_biased(cls_deproj_msk)
+    check_biased(cls_deproj_msk)

--- a/pymaster/tests/test_field_catalog.py
+++ b/pymaster/tests/test_field_catalog.py
@@ -253,6 +253,11 @@ def test_field_catalog_errors():
         nmt.NmtFieldCatalogClustering([[0., 0.], [1., 1.]], [1., 1.],
                                       [[0., 0.], [1., 1.]], [1., 1.], 10)
     nmt.utils.HAVE_DUCC = True
+    # Wrong template size ([1, npix] instead of [1, 1, npix])
+    with pytest.raises(ValueError):
+        nmt.NmtFieldCatalogClustering([[0., 0.], [1., 1.]], [1., 1.],
+                                      [[0., 0.], [1., 1.]], [1., 1.], 10,
+                                      templates=np.zeros([1, 12*64**2]))
 
 
 def test_field_catalog_clustering_poisson():

--- a/pymaster/tests/test_field_catalog.py
+++ b/pymaster/tests/test_field_catalog.py
@@ -258,6 +258,10 @@ def test_field_catalog_errors():
         nmt.NmtFieldCatalogClustering([[0., 0.], [1., 1.]], [1., 1.],
                                       [[0., 0.], [1., 1.]], [1., 1.], 10,
                                       templates=np.zeros([1, 12*64**2]))
+    with pytest.raises(ValueError):
+        nmt.NmtFieldCatalogClustering([[0., 0.], [1., 1.]], [1., 1.],
+                                      [[0., 0.], [1., 1.]], [1., 1.], 10,
+                                      templates=-5)
 
 
 def test_field_catalog_clustering_poisson():


### PR DESCRIPTION
`NmtFieldCatalogClustering` now optionally performs systematics mitigation via mode deprojection. The method involves calculating the contribution of the systematics templates at the $a_{\ell m}$ level and subtracting that from the $a_{\ell m}$ of the masked field. 

A few extra, optional arguments have been added to facilitate this. These include:
- `templates`: array containing the systematics maps (or `None`, in which case `NmtFieldCatalogClustering` functions exactly as before)
- `mask`:  array containing the survey mask (or `None`, in which case the randoms positions are used to compute a mask)
- `masked_on_input`: boolean to specify if the templates have already had a mask applied to them, in which case `mask` is ignored
- `n_iter`, `wcs`, and `tol_pinv`: all the same as in `NmtField`
